### PR TITLE
Add AVR demo crate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ todo.txt
 *.sk
 *.sig
 *.py
+!avr_demo/simavr_wrapper.py
 Cargo.lock
 deps/
 testdata/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,4 @@
 resolver = "2"
 
 members = [ "ed25519" ]
+exclude = [ "avr_demo" ]

--- a/avr_demo/.cargo/config.toml
+++ b/avr_demo/.cargo/config.toml
@@ -1,0 +1,10 @@
+[build]
+target = "avr-none"
+rustflags = ["-C", "target-cpu=atmega2560"]
+
+[unstable]
+build-std = ["core"]
+
+[target.avr-none]
+# Run simavr through wrapper so WSL can be used on Windows
+runner = "python3 simavr_wrapper.py -t 30 -m atmega2560 -f 16000000"

--- a/avr_demo/Cargo.toml
+++ b/avr_demo/Cargo.toml
@@ -1,0 +1,35 @@
+cargo-features = ["profile-rustflags"]
+
+[package]
+name = "avr_demo"
+version = "0.1.0"
+edition = "2024"
+autobins = false
+autotests = false
+autobenches = false
+
+[dependencies]
+ed25519_heapless = { path = "../ed25519", default-features = false, features = ["fixed-bigint", "fixed-bigint-u8"] }
+fixed-bigint = { version = "0.2.5", features = ["use-unsafe"] }
+ufmt = { version = "0.2" }
+
+[dependencies.arduino-hal]
+git = "https://github.com/rahix/avr-hal"
+rev = "ravedude-0.2.0"
+features = ["arduino-mega2560"]
+
+[profile.dev]
+panic = "abort"
+lto = "fat"
+opt-level = "z"
+codegen-units = 1
+strip = "none"
+debug = "full"
+rustflags = ["-Z", "ub-checks=no"]
+
+[profile.release]
+panic = "abort"
+codegen-units = 1
+debug = true
+lto = true
+opt-level = "s"

--- a/avr_demo/build.rs
+++ b/avr_demo/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/avr_demo/examples/stack_map.rs
+++ b/avr_demo/examples/stack_map.rs
@@ -53,7 +53,8 @@ fn print_stack_map(serial: &mut impl ufmt::uWrite) {
         }
 
         // '#' = mostly used, '.' = mostly unused, ':' = partial
-        if watermark_count == chunk_size {
+        let actual_chunk_size = chunk_end_addr - (addr as u16);
+        if watermark_count == actual_chunk_size {
             ufmt::uwrite!(serial, ".").ok();
         } else if watermark_count == 0 {
             ufmt::uwrite!(serial, "#").ok();

--- a/avr_demo/examples/stack_map.rs
+++ b/avr_demo/examples/stack_map.rs
@@ -1,0 +1,127 @@
+#![no_std]
+#![no_main]
+#![feature(asm_experimental_arch)]
+
+use avr_demo as _;
+use avr_demo::stack_measurement::*;
+use fixed_bigint::FixedUInt;
+
+const PUBLIC_KEY: [u8; 32] = [
+    0x33, 0xbc, 0x91, 0xa3, 0xca, 0xb8, 0x87, 0xc8, 0xbf, 0x3c, 0x63, 0x61, 0x46, 0xd2, 0xe3, 0x8d,
+    0x58, 0xd0, 0xca, 0xf3, 0x3b, 0x77, 0x86, 0x25, 0xc7, 0x95, 0x2b, 0xc7, 0x6f, 0xc0, 0x73, 0xac,
+];
+const SIGNATURE: [u8; 64] = [
+    0x2f, 0xec, 0x62, 0xdf, 0x49, 0x4f, 0xf5, 0x70, 0x5f, 0x5c, 0xee, 0x45, 0xbc, 0x5e, 0x89, 0xc2,
+    0x32, 0xc1, 0x61, 0x88, 0x37, 0x87, 0xce, 0x50, 0xa2, 0x9b, 0xe8, 0x8c, 0xb1, 0x92, 0xc8, 0x81,
+    0x25, 0x62, 0x74, 0xed, 0xd7, 0x67, 0x2a, 0xa5, 0x52, 0x79, 0x57, 0xeb, 0x0d, 0xdc, 0x0e, 0x60,
+    0x95, 0x23, 0x74, 0x36, 0x22, 0x32, 0x85, 0xf6, 0xd9, 0x30, 0x6b, 0x96, 0x63, 0x14, 0x86, 0x02,
+];
+const MESSAGE: &[u8] = b"Hello world!\n";
+
+const RAMEND_ADDR: u16 = 0x21FF;
+
+unsafe extern "C" {
+    static mut _end: u8;
+}
+
+/// Print a visual map of stack usage in 64-byte chunks
+/// Shows '#' for used (watermark overwritten) and '.' for unused (watermark intact)
+fn print_stack_map(serial: &mut impl ufmt::uWrite) {
+    let stack_start = unsafe { &raw mut _end as *const u8 };
+    let stack_end = RAMEND_ADDR as *const u8;
+    let total = unsafe { stack_end.offset_from(stack_start) as u16 };
+
+    ufmt::uwriteln!(serial, "Stack map ({} bytes, 32B/char):", total).ok();
+    ufmt::uwrite!(serial, "LO|").ok();
+
+    let chunk_size: u16 = 32;
+    let mut addr = stack_start;
+    let mut chunk_idx: u16 = 0;
+
+    while (addr as u16) < (stack_end as u16) {
+        // Count watermark bytes in this chunk
+        let chunk_end_addr = (addr as u16)
+            .saturating_add(chunk_size)
+            .min(stack_end as u16);
+        let mut watermark_count: u16 = 0;
+        let mut scan = addr;
+        while (scan as u16) < chunk_end_addr {
+            if unsafe { core::ptr::read_volatile(scan) } == 0xCE {
+                watermark_count += 1;
+            }
+            scan = unsafe { scan.add(1) };
+        }
+
+        // '#' = mostly used, '.' = mostly unused, ':' = partial
+        if watermark_count == chunk_size {
+            ufmt::uwrite!(serial, ".").ok();
+        } else if watermark_count == 0 {
+            ufmt::uwrite!(serial, "#").ok();
+        } else {
+            ufmt::uwrite!(serial, ":").ok();
+        }
+
+        addr = chunk_end_addr as *const u8;
+        chunk_idx += 1;
+        if chunk_idx % 80 == 0 {
+            ufmt::uwriteln!(serial, "").ok();
+            ufmt::uwrite!(serial, "   ").ok();
+        }
+    }
+    ufmt::uwriteln!(serial, "|HI").ok();
+
+    // Also print per-256B region summary with byte counts
+    ufmt::uwriteln!(serial, "").ok();
+    ufmt::uwriteln!(serial, "Per-256B region (used/256):").ok();
+    let mut region_addr = stack_start;
+    let mut region_idx: u16 = 0;
+    while (region_addr as u16) < (stack_end as u16) {
+        let region_end = ((region_addr as u16).saturating_add(256)).min(stack_end as u16);
+        let mut used: u16 = 0;
+        let mut scan = region_addr;
+        while (scan as u16) < region_end {
+            if unsafe { core::ptr::read_volatile(scan) } != 0xCE {
+                used += 1;
+            }
+            scan = unsafe { scan.add(1) };
+        }
+        let region_size = region_end - region_addr as u16;
+        ufmt::uwriteln!(
+            serial,
+            "  {:04X}: {}/{}",
+            region_addr as u16,
+            used,
+            region_size
+        )
+        .ok();
+        region_addr = region_end as *const u8;
+        region_idx += 1;
+    }
+    ufmt::uwriteln!(serial, "  Total free RAM: {}", total).ok();
+}
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    unsafe { fill_stack_with_watermark() };
+
+    let result = ed25519_heapless::verify::<FixedUInt<u8, 32>>(PUBLIC_KEY, MESSAGE, SIGNATURE);
+
+    let stack_used = unsafe { measure_stack_usage() };
+
+    if result {
+        ufmt::uwriteln!(&mut serial, "ACCEPT").ok();
+    } else {
+        ufmt::uwriteln!(&mut serial, "REJECT").ok();
+    }
+    ufmt::uwriteln!(&mut serial, "Max stack usage: {} bytes", stack_used).ok();
+
+    print_stack_map(&mut serial);
+
+    loop {
+        unsafe { core::arch::asm!("sleep") }
+    }
+}

--- a/avr_demo/examples/test_verify.rs
+++ b/avr_demo/examples/test_verify.rs
@@ -1,0 +1,57 @@
+#![no_std]
+#![no_main]
+#![feature(asm_experimental_arch)]
+
+use avr_demo as _;
+use avr_demo::stack_measurement::*;
+use fixed_bigint::FixedUInt;
+
+// --- Test vectors ---
+
+const PUBLIC_KEY: [u8; 32] = [
+    0x33, 0xbc, 0x91, 0xa3, 0xca, 0xb8, 0x87, 0xc8, 0xbf, 0x3c, 0x63, 0x61, 0x46, 0xd2, 0xe3, 0x8d,
+    0x58, 0xd0, 0xca, 0xf3, 0x3b, 0x77, 0x86, 0x25, 0xc7, 0x95, 0x2b, 0xc7, 0x6f, 0xc0, 0x73, 0xac,
+];
+const SIGNATURE: [u8; 64] = [
+    0x2f, 0xec, 0x62, 0xdf, 0x49, 0x4f, 0xf5, 0x70, 0x5f, 0x5c, 0xee, 0x45, 0xbc, 0x5e, 0x89, 0xc2,
+    0x32, 0xc1, 0x61, 0x88, 0x37, 0x87, 0xce, 0x50, 0xa2, 0x9b, 0xe8, 0x8c, 0xb1, 0x92, 0xc8, 0x81,
+    0x25, 0x62, 0x74, 0xed, 0xd7, 0x67, 0x2a, 0xa5, 0x52, 0x79, 0x57, 0xeb, 0x0d, 0xdc, 0x0e, 0x60,
+    0x95, 0x23, 0x74, 0x36, 0x22, 0x32, 0x85, 0xf6, 0xd9, 0x30, 0x6b, 0x96, 0x63, 0x14, 0x86, 0x02,
+];
+const MESSAGE: &[u8] = b"Hello world!\n";
+
+#[arduino_hal::entry]
+fn main() -> ! {
+    let dp = arduino_hal::Peripherals::take().unwrap();
+    let pins = arduino_hal::pins!(dp);
+    let mut serial = arduino_hal::default_serial!(dp, pins, 57600);
+
+    // Use TC1 (16-bit) in normal mode, prescaler 1024 → 15625 Hz at 16MHz
+    // Max measurable: 65536/15625 = 4.19 seconds. 1 tick = 64µs.
+    let tc1 = &dp.TC1;
+    tc1.tccr1b.write(|w| w.cs1().prescale_1024());
+
+    unsafe { fill_stack_with_watermark() };
+
+    let start: u16 = tc1.tcnt1.read().bits();
+    let result = ed25519_heapless::verify::<FixedUInt<u8, 32>>(PUBLIC_KEY, MESSAGE, SIGNATURE);
+    let end: u16 = tc1.tcnt1.read().bits();
+
+    let stack_used = unsafe { measure_stack_usage() };
+
+    // ticks * 1000 / 15625 = ms, but use integer math: ticks * 8 / 125
+    let ticks = end.wrapping_sub(start);
+    let ms = (ticks as u32) * 8 / 125;
+
+    if result {
+        ufmt::uwriteln!(&mut serial, "ACCEPT").ok();
+    } else {
+        ufmt::uwriteln!(&mut serial, "REJECT").ok();
+    }
+    ufmt::uwriteln!(&mut serial, "Time: {} ms ({} ticks)", ms, ticks).ok();
+    ufmt::uwriteln!(&mut serial, "Max stack usage: {} bytes", stack_used).ok();
+
+    loop {
+        unsafe { core::arch::asm!("sleep") }
+    }
+}

--- a/avr_demo/rust-toolchain.toml
+++ b/avr_demo/rust-toolchain.toml
@@ -1,0 +1,14 @@
+# Pinned to last known good nightly before AVR DEV build panic regression
+# Regression: nightly-2025-12-23 introduced spurious panic symbols in DEV profile
+[toolchain]
+channel = "nightly-2025-11-01"
+components = [
+    "rustc",
+    "cargo",
+    "clippy",
+    "rustfmt",
+    "rust-src",
+    "rust-analyzer",
+    "llvm-tools"
+]
+profile = "minimal"

--- a/avr_demo/simavr_wrapper.py
+++ b/avr_demo/simavr_wrapper.py
@@ -1,0 +1,110 @@
+import platform
+import subprocess
+import sys
+import os
+import argparse
+import shlex
+
+def run_simavr_posix(binary, simavr_args, timeout_seconds=None):
+    """Run simavr directly on Linux with all arguments passed through."""
+    cmd = ["simavr"] + simavr_args + [binary]
+
+    if timeout_seconds:
+        cmd = ["timeout", str(timeout_seconds)] + cmd
+
+    try:
+        result = subprocess.run(cmd, check=False)
+        return result.returncode
+    except FileNotFoundError:
+        print("Error: simavr not found. Please ensure it's installed and in PATH.", file=sys.stderr)
+        return 1
+
+def run_simavr_windows(binary, simavr_args, timeout_seconds=None):
+    """Run simavr through WSL on Windows with path conversion."""
+    try:
+        abs_binary_path = os.path.abspath(binary)
+        normalized_path = abs_binary_path.replace('\\', '/')
+
+        wsl_binary_result = subprocess.run(
+            ["wsl", "wslpath", "-u", normalized_path],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+        wsl_binary_path = wsl_binary_result.stdout.strip()
+
+        simavr_cmd_parts = ["simavr"] + simavr_args + [wsl_binary_path]
+
+        if timeout_seconds:
+            simavr_cmd_parts = ["timeout", str(timeout_seconds)] + simavr_cmd_parts
+
+        cmd = ["wsl", "-e", "bash", "-c", " ".join(shlex.quote(part) for part in simavr_cmd_parts)]
+        result = subprocess.run(cmd, check=False)
+        return result.returncode
+
+    except subprocess.CalledProcessError as e:
+        print(f"Error converting path with wslpath: {e}", file=sys.stderr)
+        return 1
+    except FileNotFoundError:
+        print("Error: WSL not found. Please ensure WSL is installed and configured.", file=sys.stderr)
+        return 1
+
+def main():
+    # Custom parsing needed because argparse can't handle mixed arguments properly
+    # We need to extract -t/--timeout but pass everything else to simavr
+    timeout_seconds = None
+    simavr_args = []
+    binary = None
+
+    i = 1  # Skip script name
+    while i < len(sys.argv):
+        arg = sys.argv[i]
+
+        if arg in ['-t', '--timeout']:
+            if i + 1 >= len(sys.argv):
+                print("Error: -t/--timeout requires a value", file=sys.stderr)
+                sys.exit(1)
+            try:
+                timeout_seconds = int(sys.argv[i + 1])
+                if timeout_seconds <= 0:
+                    raise ValueError()
+            except ValueError:
+                print("Error: timeout value must be a positive integer", file=sys.stderr)
+                sys.exit(1)
+            i += 2  # Skip both the flag and its value
+        elif arg.endswith('.elf') or arg.endswith('.bin') or arg.endswith('.hex'):
+            # This looks like a binary file
+            binary = arg
+            i += 1
+        else:
+            # This is a simavr argument
+            simavr_args.append(arg)
+            i += 1
+
+    # If no binary was found, assume the last argument is the binary
+    if binary is None and simavr_args:
+        binary = simavr_args.pop()
+
+    if binary is None:
+        print("Error: No binary file specified", file=sys.stderr)
+        print("Usage: simavr_wrapper.py [-t timeout] [simavr_args...] <binary.elf>", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.exists(binary):
+        print(f"Error: Binary file '{binary}' not found.", file=sys.stderr)
+        sys.exit(1)
+
+    system = platform.system().lower()
+
+    if system in ["linux", "darwin"]:
+        exit_code = run_simavr_posix(binary, simavr_args, timeout_seconds)
+    elif system == "windows":
+        exit_code = run_simavr_windows(binary, simavr_args, timeout_seconds)
+    else:
+        print(f"Error: Unsupported operating system: {system}", file=sys.stderr)
+        sys.exit(1)
+
+    sys.exit(exit_code)
+
+if __name__ == "__main__":
+    main()

--- a/avr_demo/simavr_wrapper.py
+++ b/avr_demo/simavr_wrapper.py
@@ -2,19 +2,18 @@ import platform
 import subprocess
 import sys
 import os
-import argparse
 import shlex
 
 def run_simavr_posix(binary, simavr_args, timeout_seconds=None):
-    """Run simavr directly on Linux with all arguments passed through."""
+    """Run simavr directly on Linux/macOS with all arguments passed through."""
     cmd = ["simavr"] + simavr_args + [binary]
 
-    if timeout_seconds:
-        cmd = ["timeout", str(timeout_seconds)] + cmd
-
     try:
-        result = subprocess.run(cmd, check=False)
+        result = subprocess.run(cmd, check=False, timeout=timeout_seconds)
         return result.returncode
+    except subprocess.TimeoutExpired:
+        print(f"Error: simavr timed out after {timeout_seconds}s", file=sys.stderr)
+        return 124  # Match GNU timeout exit code
     except FileNotFoundError:
         print("Error: simavr not found. Please ensure it's installed and in PATH.", file=sys.stderr)
         return 1
@@ -50,8 +49,6 @@ def run_simavr_windows(binary, simavr_args, timeout_seconds=None):
         return 1
 
 def main():
-    # Custom parsing needed because argparse can't handle mixed arguments properly
-    # We need to extract -t/--timeout but pass everything else to simavr
     timeout_seconds = None
     simavr_args = []
     binary = None

--- a/avr_demo/src/lib.rs
+++ b/avr_demo/src/lib.rs
@@ -1,0 +1,14 @@
+#![no_std]
+
+pub mod stack_measurement;
+
+// Panic handler - registered automatically when crate is imported
+#[inline(never)]
+fn inner_panic_handler() -> ! {
+    loop {}
+}
+
+#[panic_handler]
+pub fn panic_handler(_info: &core::panic::PanicInfo) -> ! {
+    inner_panic_handler();
+}

--- a/avr_demo/src/lib.rs
+++ b/avr_demo/src/lib.rs
@@ -1,4 +1,5 @@
 #![no_std]
+#![feature(asm_experimental_arch)]
 
 pub mod stack_measurement;
 

--- a/avr_demo/src/stack_measurement.rs
+++ b/avr_demo/src/stack_measurement.rs
@@ -1,0 +1,70 @@
+// The magic value we'll use to fill the stack area.
+const STACK_WATERMARK: u8 = 0xCE;
+
+// For the ATmega2560, RAMEND is at address 0x21FF.
+const RAMEND_ADDR: u16 = 0x21FF;
+
+// Linker symbol that marks the end of the .bss section.
+unsafe extern "C" {
+    static mut _end: u8;
+}
+
+/// Fills the unused RAM with a magic value.
+pub unsafe fn fill_stack_with_watermark() {
+    let stack_start_ptr = &raw mut _end as *mut u8;
+    let stack_end_ptr = RAMEND_ADDR as *mut u8;
+
+    // Even inside an `unsafe fn`, these operations now require an `unsafe` block.
+    unsafe {
+        let mut current_ptr = stack_start_ptr;
+        while current_ptr <= stack_end_ptr {
+            core::ptr::write_volatile(current_ptr, STACK_WATERMARK);
+            current_ptr = current_ptr.add(1);
+        }
+    }
+}
+
+/// Measures the maximum stack usage by finding the "high-water mark".
+/// This is unsafe because we are reading from a large, arbitrary memory region.
+pub unsafe fn measure_stack_usage() -> u16 {
+    let stack_start_ptr = &raw const _end as *const u8;
+    let stack_end_ptr = RAMEND_ADDR as *const u8;
+
+    // Validate memory region bounds before proceeding
+    if stack_start_ptr > stack_end_ptr {
+        return 0; // Invalid memory layout
+    }
+
+    unsafe {
+        let mut current_ptr = stack_start_ptr;
+
+        // Add explicit bounds checking in the loop condition
+        while current_ptr < stack_end_ptr {
+            // Validate pointer is still within bounds before reading
+            if current_ptr > stack_end_ptr {
+                break; // Safety check - should not happen but prevents overflow
+            }
+
+            if core::ptr::read_volatile(current_ptr) != STACK_WATERMARK {
+                // We found the first byte that was overwritten. This is our high-water mark.
+                // The stack grows downwards from RAMEND, so the usage is the distance from the top.
+                return (stack_end_ptr as u16) - (current_ptr as u16);
+            }
+
+            // Check for potential overflow before incrementing
+            if current_ptr == stack_end_ptr {
+                break; // At boundary, prevent overflow
+            }
+
+            current_ptr = current_ptr.add(1);
+        }
+
+        // Handle edge case: check the final byte at stack_end_ptr
+        if current_ptr == stack_end_ptr && core::ptr::read_volatile(current_ptr) != STACK_WATERMARK
+        {
+            return (stack_end_ptr as u16) - (current_ptr as u16);
+        }
+    }
+
+    0 // Should not happen if stack was used at all.
+}

--- a/avr_demo/src/stack_measurement.rs
+++ b/avr_demo/src/stack_measurement.rs
@@ -9,15 +9,29 @@ unsafe extern "C" {
     static mut _end: u8;
 }
 
-/// Fills the unused RAM with a magic value.
+/// Read the current stack pointer via inline assembly.
+#[inline(always)]
+fn read_sp() -> u16 {
+    let lo: u8;
+    let hi: u8;
+    unsafe {
+        core::arch::asm!("in {}, 0x3D", out(reg) lo); // SPL
+        core::arch::asm!("in {}, 0x3E", out(reg) hi); // SPH
+    }
+    (hi as u16) << 8 | lo as u16
+}
+
+/// Fills the unused RAM (from _end up to current SP) with a magic value.
+/// Only paints below the current stack pointer to avoid overwriting live frames.
 pub unsafe fn fill_stack_with_watermark() {
     let stack_start_ptr = &raw mut _end as *mut u8;
-    let stack_end_ptr = RAMEND_ADDR as *mut u8;
+    // Leave a safety margin below SP for this function's own frame
+    let sp = read_sp();
+    let safe_end = (sp - 64) as *mut u8; // 64 bytes margin
 
-    // Even inside an `unsafe fn`, these operations now require an `unsafe` block.
     unsafe {
         let mut current_ptr = stack_start_ptr;
-        while current_ptr <= stack_end_ptr {
+        while current_ptr < safe_end {
             core::ptr::write_volatile(current_ptr, STACK_WATERMARK);
             current_ptr = current_ptr.add(1);
         }
@@ -25,46 +39,21 @@ pub unsafe fn fill_stack_with_watermark() {
 }
 
 /// Measures the maximum stack usage by finding the "high-water mark".
-/// This is unsafe because we are reading from a large, arbitrary memory region.
+/// Scans from _end upward; first byte not matching the watermark indicates
+/// where the stack grew to. Usage = RAMEND - that address.
 pub unsafe fn measure_stack_usage() -> u16 {
     let stack_start_ptr = &raw const _end as *const u8;
     let stack_end_ptr = RAMEND_ADDR as *const u8;
 
-    // Validate memory region bounds before proceeding
-    if stack_start_ptr > stack_end_ptr {
-        return 0; // Invalid memory layout
-    }
-
     unsafe {
         let mut current_ptr = stack_start_ptr;
-
-        // Add explicit bounds checking in the loop condition
         while current_ptr < stack_end_ptr {
-            // Validate pointer is still within bounds before reading
-            if current_ptr > stack_end_ptr {
-                break; // Safety check - should not happen but prevents overflow
-            }
-
             if core::ptr::read_volatile(current_ptr) != STACK_WATERMARK {
-                // We found the first byte that was overwritten. This is our high-water mark.
-                // The stack grows downwards from RAMEND, so the usage is the distance from the top.
                 return (stack_end_ptr as u16) - (current_ptr as u16);
             }
-
-            // Check for potential overflow before incrementing
-            if current_ptr == stack_end_ptr {
-                break; // At boundary, prevent overflow
-            }
-
             current_ptr = current_ptr.add(1);
-        }
-
-        // Handle edge case: check the final byte at stack_end_ptr
-        if current_ptr == stack_end_ptr && core::ptr::read_volatile(current_ptr) != STACK_WATERMARK
-        {
-            return (stack_end_ptr as u16) - (current_ptr as u16);
         }
     }
 
-    0 // Should not happen if stack was used at all.
+    0
 }

--- a/avr_demo/src/stack_measurement.rs
+++ b/avr_demo/src/stack_measurement.rs
@@ -10,13 +10,17 @@ unsafe extern "C" {
 }
 
 /// Read the current stack pointer via inline assembly.
+/// Interrupts are disabled around the two-byte read to prevent a race
+/// between SPL and SPH if an ISR fires in between.
 #[inline(always)]
 fn read_sp() -> u16 {
     let lo: u8;
     let hi: u8;
     unsafe {
+        core::arch::asm!("cli"); // disable interrupts
         core::arch::asm!("in {}, 0x3D", out(reg) lo); // SPL
         core::arch::asm!("in {}, 0x3E", out(reg) hi); // SPH
+        core::arch::asm!("sei"); // re-enable interrupts
     }
     (hi as u16) << 8 | lo as u16
 }
@@ -47,7 +51,7 @@ pub unsafe fn measure_stack_usage() -> u16 {
 
     unsafe {
         let mut current_ptr = stack_start_ptr;
-        while current_ptr < stack_end_ptr {
+        while current_ptr <= stack_end_ptr {
             if core::ptr::read_volatile(current_ptr) != STACK_WATERMARK {
                 return (stack_end_ptr as u16) - (current_ptr as u16);
             }


### PR DESCRIPTION
## Summary
- Standalone `avr_demo/` crate running ed25519 verify on ATmega2560 via simavr
- Uses `FixedUInt<u8, 32>` backend, pinned nightly-2025-11-01
- Stack usage ~3.3KB (well under 8KB RAM), ~1.4s verify time at 16MHz
- Includes `simavr_wrapper.py` for cross-platform runner (Linux/macOS/WSL)
- Two examples: `test_verify` (timing + stack measurement) and `stack_map` (visual stack usage map)

## Test plan
- [x] `cargo build --release --example test_verify` compiles
- [x] `cargo run --release --example test_verify` prints ACCEPT with metrics
- [x] Host `cargo test` still passes (avr_demo excluded from workspace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Add a standalone AVR demo crate that runs ed25519 signature verification on an ATmega2560 target and is excluded from the main workspace build.

New Features:
- Introduce the `avr_demo` no_std crate targeting `avr-none` with Arduino Mega 2560 support and a minimal panic handler.
- Add `test_verify` and `stack_map` examples to measure timing and visualize stack usage while performing ed25519 verification using a fixed-bigint backend.
- Provide a cross-platform `simavr_wrapper.py` script and cargo runner configuration to run the compiled AVR binary under simavr on Linux, macOS, and Windows via WSL.

Enhancements:
- Pin a dedicated nightly toolchain for the AVR demo to a known-good version and configure optimized build profiles for size and abort-on-panic behavior.
- Add reusable stack watermarking and measurement utilities for analyzing RAM usage on the AVR target.

Build:
- Exclude `avr_demo` from the root Cargo workspace to avoid impacting existing host builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AVR demo with examples for signature verification and stack-usage visualization on Arduino-compatible hardware.
  * Added a cross-platform simavr runner with Windows/WSL support for local simulation.

* **Chores**
  * Updated workspace configuration and Cargo settings to support AVR targets and cross-compilation.
  * Added toolchain pinning and build config for reproducible AVR builds and a small build script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->