### PR TITLE
Add embedded CI workflows for AVR and Cortex-M

### DIFF
--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -20,10 +20,22 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2025-11-01
-        components: rust-src
+        components: rust-src, llvm-tools
 
     - name: Install simavr and AVR toolchain
       run: sudo apt-get update && sudo apt-get install -y simavr gcc-avr avr-libc
+
+    - name: Cache cargo binaries
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-size
+        key: ${{ runner.os }}-cargo-binutils-v1
+
+    - name: Install cargo-binutils
+      run: |
+        if ! command -v cargo-size &> /dev/null; then
+          cargo install cargo-binutils --locked
+        fi
 
     - uses: actions/cache@v4
       with:

--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -1,0 +1,39 @@
+name: AVR
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  avr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2025-11-01
+        components: rust-src
+
+    - name: Install simavr and AVR toolchain
+      run: sudo apt-get update && sudo apt-get install -y simavr gcc-avr avr-libc
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          avr_demo/target
+        key: avr-${{ hashFiles('avr_demo/Cargo.toml', 'ed25519/Cargo.toml') }}
+        restore-keys: avr-
+
+    - name: Run AVR suite
+      run: python3 run_suite.py | tee -a "$GITHUB_STEP_SUMMARY"
+      working-directory: avr_demo

--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -2,7 +2,7 @@ name: AVR
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: nightly-2025-11-01
-        components: rust-src, llvm-tools
+        components: rust-src
 
     - name: Install simavr and AVR toolchain
       run: sudo apt-get update && sudo apt-get install -y simavr gcc-avr avr-libc
@@ -28,13 +28,13 @@ jobs:
     - name: Cache cargo binaries
       uses: actions/cache@v4
       with:
-        path: ~/.cargo/bin/cargo-size
-        key: ${{ runner.os }}-cargo-binutils-v1
+        path: ~/.cargo/bin/cargo-bloat
+        key: ${{ runner.os }}-cargo-bloat-v1
 
-    - name: Install cargo-binutils
+    - name: Install cargo-bloat
       run: |
-        if ! command -v cargo-size &> /dev/null; then
-          cargo install cargo-binutils --locked
+        if ! command -v cargo-bloat &> /dev/null; then
+          cargo install cargo-bloat --locked
         fi
 
     - uses: actions/cache@v4

--- a/.github/workflows/avr.yml
+++ b/.github/workflows/avr.yml
@@ -35,5 +35,7 @@ jobs:
         restore-keys: avr-
 
     - name: Run AVR suite
-      run: python3 run_suite.py | tee -a "$GITHUB_STEP_SUMMARY"
+      run: |
+        set -o pipefail
+        python3 run_suite.py | tee -a "$GITHUB_STEP_SUMMARY"
       working-directory: avr_demo

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         targets: thumbv6m-none-eabi, thumbv7m-none-eabi, thumbv7em-none-eabi
-        components: llvm-tools-preview
+        components: llvm-tools
 
     - name: Install QEMU
       run: sudo apt-get update && sudo apt-get install -y qemu-system-arm

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -20,7 +20,6 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         targets: thumbv6m-none-eabi, thumbv7m-none-eabi, thumbv7em-none-eabi
-        components: llvm-tools
 
     - name: Install QEMU
       run: sudo apt-get update && sudo apt-get install -y qemu-system-arm
@@ -28,13 +27,13 @@ jobs:
     - name: Cache cargo binaries
       uses: actions/cache@v4
       with:
-        path: ~/.cargo/bin/cargo-size
-        key: ${{ runner.os }}-cargo-binutils-v1
+        path: ~/.cargo/bin/cargo-bloat
+        key: ${{ runner.os }}-cargo-bloat-v1
 
-    - name: Install cargo-binutils
+    - name: Install cargo-bloat
       run: |
-        if ! command -v cargo-size &> /dev/null; then
-          cargo install cargo-binutils --locked
+        if ! command -v cargo-bloat &> /dev/null; then
+          cargo install cargo-bloat --locked
         fi
 
     - uses: actions/cache@v4

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -35,5 +35,7 @@ jobs:
         restore-keys: cortex-m-
 
     - name: Run Cortex-M suite
-      run: python3 run_suite.py | tee -a "$GITHUB_STEP_SUMMARY"
+      run: |
+        set -o pipefail
+        python3 run_suite.py | tee -a "$GITHUB_STEP_SUMMARY"
       working-directory: cortex_m_demo

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -1,0 +1,39 @@
+name: Cortex-M
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * 1'  # Weekly on Monday at 06:00 UTC
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  cortex-m:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: thumbv6m-none-eabi, thumbv7m-none-eabi, thumbv7em-none-eabi
+        components: llvm-tools-preview
+
+    - name: Install QEMU
+      run: sudo apt-get update && sudo apt-get install -y qemu-system-arm
+
+    - uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+          cortex_m_demo/target
+        key: cortex-m-${{ hashFiles('cortex_m_demo/Cargo.toml', 'ed25519/Cargo.toml') }}
+        restore-keys: cortex-m-
+
+    - name: Run Cortex-M suite
+      run: python3 run_suite.py | tee -a "$GITHUB_STEP_SUMMARY"
+      working-directory: cortex_m_demo

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -2,7 +2,7 @@ name: Cortex-M
 
 on:
   push:
-    branches: ["*"]
+    branches: ["**"]
   pull_request:
   workflow_dispatch:
   schedule:

--- a/.github/workflows/cortex_m.yml
+++ b/.github/workflows/cortex_m.yml
@@ -25,6 +25,18 @@ jobs:
     - name: Install QEMU
       run: sudo apt-get update && sudo apt-get install -y qemu-system-arm
 
+    - name: Cache cargo binaries
+      uses: actions/cache@v4
+      with:
+        path: ~/.cargo/bin/cargo-size
+        key: ${{ runner.os }}-cargo-binutils-v1
+
+    - name: Install cargo-binutils
+      run: |
+        if ! command -v cargo-size &> /dev/null; then
+          cargo install cargo-binutils --locked
+        fi
+
     - uses: actions/cache@v4
       with:
         path: |

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ todo.txt
 *.sig
 *.py
 !avr_demo/simavr_wrapper.py
+!avr_demo/run_suite.py
+!cortex_m_demo/run_suite.py
 Cargo.lock
 deps/
 testdata/

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -4,6 +4,7 @@
 Generates a markdown metrics table from the results.
 """
 
+import json
 import re
 import subprocess
 import sys
@@ -46,37 +47,23 @@ def run_simavr():
     return combined
 
 
-def parse_text_size(output):
-    """Parse .text size from size -A output."""
-    for line in output.splitlines():
-        if line.startswith(".text"):
-            parts = line.split()
-            if len(parts) >= 2:
-                return int(parts[1])
-    return None
-
-
 def get_text_size():
-    """Get .text section size via cargo-size, falling back to avr-size."""
-    # cargo-size wraps llvm-size from the toolchain
+    """Get .text section size via cargo-bloat JSON output."""
     try:
-        rc, out, _ = run_cmd([
-            "cargo", "size", "--release", "--example", EXAMPLE, "--", "-A",
-        ])
+        rc, out, err = run_cmd([
+            "cargo", "bloat", "--release", "--example", EXAMPLE,
+            "--message-format=json",
+        ], timeout=TIMEOUT_BUILD)
         if rc == 0:
-            size = parse_text_size(out)
-            if size is not None:
-                return size
+            json_line = out.strip().split('\n')[-1]
+            data = json.loads(json_line)
+            return data.get("text-section-size")
+        else:
+            print(f"    cargo-bloat failed (rc={rc}): {err.strip()}", file=sys.stderr)
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        print(f"    cargo-size not available: {e}", file=sys.stderr)
-    # Fallback: try avr-size directly on the ELF
-    elf = f"target/avr-none/release/examples/{EXAMPLE}.elf"
-    try:
-        rc, out, _ = run_cmd(["avr-size", "-A", elf])
-        if rc == 0:
-            return parse_text_size(out)
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        print(f"    avr-size not available: {e}", file=sys.stderr)
+        print(f"    cargo-bloat not available: {e}", file=sys.stderr)
+    except (json.JSONDecodeError, IndexError) as e:
+        print(f"    cargo-bloat JSON parse error: {e}", file=sys.stderr)
     return None
 
 

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Build and run ed25519 verification on simavr for AVR ATmega2560.
+
+Generates a markdown metrics table from the results.
+"""
+
+import re
+import subprocess
+import sys
+
+EXAMPLE = "test_verify"
+TIMEOUT = 120  # seconds per simavr run
+
+
+def run_cmd(args, **kwargs):
+    """Run a command, return (returncode, stdout, stderr)."""
+    result = subprocess.run(
+        args, capture_output=True, text=True, timeout=TIMEOUT, **kwargs
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def build():
+    """Build the example. Returns True on success."""
+    rc, out, err = run_cmd(
+        ["cargo", "build", "--release", "--example", EXAMPLE]
+    )
+    if rc != 0:
+        print("BUILD FAILED:", file=sys.stderr)
+        print(err, file=sys.stderr)
+        return False
+    return True
+
+
+def run_simavr():
+    """Run the example via cargo run (uses .cargo/config.toml runner). Returns stdout+stderr."""
+    rc, out, err = run_cmd(
+        ["cargo", "run", "--release", "--example", EXAMPLE]
+    )
+    return out + err
+
+
+def get_text_size():
+    """Get .text section size from the ELF using avr-size."""
+    elf = f"target/avr-none/release/examples/{EXAMPLE}.elf"
+    for tool in ["avr-size", "llvm-size"]:
+        try:
+            rc, out, _ = run_cmd([tool, "-A", elf])
+            if rc == 0:
+                for line in out.splitlines():
+                    if line.startswith(".text"):
+                        parts = line.split()
+                        if len(parts) >= 2:
+                            return int(parts[1])
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+    return None
+
+
+def parse_output(output):
+    """Parse AVR serial output. Returns dict with accept, stack, time_ms, ticks."""
+    result = {"accepted": False, "stack": None, "time_ms": None, "ticks": None}
+
+    if "ACCEPT" in output:
+        result["accepted"] = True
+    elif "REJECT" in output:
+        result["accepted"] = False
+
+    m = re.search(r"Time:\s*(\d+)\s*ms\s*\((\d+)\s*ticks\)", output)
+    if m:
+        result["time_ms"] = int(m.group(1))
+        result["ticks"] = int(m.group(2))
+
+    m = re.search(r"Max stack usage:\s*(\d+)\s*bytes", output)
+    if m:
+        result["stack"] = int(m.group(1))
+
+    return result
+
+
+def main():
+    print("Building for AVR...", file=sys.stderr)
+    if not build():
+        return 1
+
+    print("  Running test_verify on simavr...", file=sys.stderr)
+    try:
+        output = run_simavr()
+    except subprocess.TimeoutExpired:
+        print("    TIMEOUT", file=sys.stderr)
+        return 1
+
+    result = parse_output(output)
+    text_size = get_text_size()
+
+    status = "ACCEPT" if result["accepted"] else "REJECT"
+    print(f"    {status}", file=sys.stderr)
+
+    # Generate markdown table
+    stack = str(result["stack"]) if result["stack"] is not None else "-"
+    time_ms = str(result["time_ms"]) if result["time_ms"] is not None else "-"
+    ticks = str(result["ticks"]) if result["ticks"] is not None else "-"
+    text_kib = f"{text_size / 1024:.1f}" if text_size is not None else "-"
+
+    print()
+    print("| Target | Backend | .text (KiB) | Stack (bytes) | Time (ms) | Ticks |")
+    print("|--------|---------|-------------|---------------|-----------|-------|")
+    print(f"| ATmega2560 | u8 | {text_kib} | {stack} | {time_ms} | {ticks} |")
+
+    if not result["accepted"]:
+        print("\nFailure: signature REJECT", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -4,6 +4,7 @@
 Generates a markdown metrics table from the results.
 """
 
+import os
 import re
 import subprocess
 import sys
@@ -40,10 +41,33 @@ def run_simavr():
     return out + err
 
 
+def find_size_tools():
+    """Return list of size tool paths to try."""
+    tools = ["avr-size", "llvm-size"]
+    # llvm-size from rustup llvm-tools lives under the sysroot
+    try:
+        result = subprocess.run(
+            ["rustc", "--print", "sysroot"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            sysroot = result.stdout.strip()
+            rustlib = os.path.join(sysroot, "lib", "rustlib")
+            if os.path.isdir(rustlib):
+                for entry in os.listdir(rustlib):
+                    candidate = os.path.join(rustlib, entry, "bin", "llvm-size")
+                    if os.path.isfile(candidate):
+                        tools.append(candidate)
+                        break
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return tools
+
+
 def get_text_size():
     """Get .text section size from the ELF using avr-size."""
     elf = f"target/avr-none/release/examples/{EXAMPLE}.elf"
-    for tool in ["avr-size", "llvm-size"]:
+    for tool in find_size_tools():
         try:
             rc, out, _ = run_cmd([tool, "-A", elf])
             if rc == 0:

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -4,7 +4,6 @@
 Generates a markdown metrics table from the results.
 """
 
-import os
 import re
 import subprocess
 import sys
@@ -41,43 +40,37 @@ def run_simavr():
     return out + err
 
 
-def find_size_tools():
-    """Return list of size tool paths to try."""
-    tools = ["avr-size", "llvm-size"]
-    # llvm-size from rustup llvm-tools lives under the sysroot
-    try:
-        result = subprocess.run(
-            ["rustc", "--print", "sysroot"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode == 0:
-            sysroot = result.stdout.strip()
-            rustlib = os.path.join(sysroot, "lib", "rustlib")
-            if os.path.isdir(rustlib):
-                for entry in os.listdir(rustlib):
-                    candidate = os.path.join(rustlib, entry, "bin", "llvm-size")
-                    if os.path.isfile(candidate):
-                        tools.append(candidate)
-                        break
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
-    return tools
+def parse_text_size(output):
+    """Parse .text size from size -A output."""
+    for line in output.splitlines():
+        if line.startswith(".text"):
+            parts = line.split()
+            if len(parts) >= 2:
+                return int(parts[1])
+    return None
 
 
 def get_text_size():
-    """Get .text section size from the ELF using avr-size."""
+    """Get .text section size via cargo-size, falling back to avr-size."""
+    # cargo-size wraps llvm-size from the toolchain
+    try:
+        rc, out, _ = run_cmd([
+            "cargo", "size", "--release", "--example", EXAMPLE, "--", "-A",
+        ])
+        if rc == 0:
+            size = parse_text_size(out)
+            if size is not None:
+                return size
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    # Fallback: try avr-size directly on the ELF
     elf = f"target/avr-none/release/examples/{EXAMPLE}.elf"
-    for tool in find_size_tools():
-        try:
-            rc, out, _ = run_cmd([tool, "-A", elf])
-            if rc == 0:
-                for line in out.splitlines():
-                    if line.startswith(".text"):
-                        parts = line.split()
-                        if len(parts) >= 2:
-                            return int(parts[1])
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+    try:
+        rc, out, _ = run_cmd(["avr-size", "-A", elf])
+        if rc == 0:
+            return parse_text_size(out)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
     return None
 
 

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -22,7 +22,7 @@ def run_cmd(args, **kwargs):
 
 def build():
     """Build the example. Returns True on success."""
-    rc, out, err = run_cmd(
+    rc, _out, err = run_cmd(
         ["cargo", "build", "--release", "--example", EXAMPLE]
     )
     if rc != 0:
@@ -34,7 +34,7 @@ def build():
 
 def run_simavr():
     """Run the example via cargo run (uses .cargo/config.toml runner). Returns stdout+stderr."""
-    rc, out, err = run_cmd(
+    _rc, out, err = run_cmd(
         ["cargo", "run", "--release", "--example", EXAMPLE]
     )
     return out + err
@@ -61,10 +61,7 @@ def parse_output(output):
     """Parse AVR serial output. Returns dict with accept, stack, time_ms, ticks."""
     result = {"accepted": False, "stack": None, "time_ms": None, "ticks": None}
 
-    if "ACCEPT" in output:
-        result["accepted"] = True
-    elif "REJECT" in output:
-        result["accepted"] = False
+    result["accepted"] = "ACCEPT" in output
 
     m = re.search(r"Time:\s*(\d+)\s*ms\s*\((\d+)\s*ticks\)", output)
     if m:

--- a/avr_demo/run_suite.py
+++ b/avr_demo/run_suite.py
@@ -9,13 +9,14 @@ import subprocess
 import sys
 
 EXAMPLE = "test_verify"
-TIMEOUT = 120  # seconds per simavr run
+TIMEOUT_RUN = 120  # seconds per simavr run
+TIMEOUT_BUILD = 600  # seconds for cargo build
 
 
-def run_cmd(args, **kwargs):
+def run_cmd(args, timeout=TIMEOUT_RUN, **kwargs):
     """Run a command, return (returncode, stdout, stderr)."""
     result = subprocess.run(
-        args, capture_output=True, text=True, timeout=TIMEOUT, **kwargs
+        args, capture_output=True, text=True, timeout=timeout, **kwargs
     )
     return result.returncode, result.stdout, result.stderr
 
@@ -23,7 +24,8 @@ def run_cmd(args, **kwargs):
 def build():
     """Build the example. Returns True on success."""
     rc, _out, err = run_cmd(
-        ["cargo", "build", "--release", "--example", EXAMPLE]
+        ["cargo", "build", "--release", "--example", EXAMPLE],
+        timeout=TIMEOUT_BUILD,
     )
     if rc != 0:
         print("BUILD FAILED:", file=sys.stderr)
@@ -34,10 +36,14 @@ def build():
 
 def run_simavr():
     """Run the example via cargo run (uses .cargo/config.toml runner). Returns stdout+stderr."""
-    _rc, out, err = run_cmd(
+    rc, out, err = run_cmd(
         ["cargo", "run", "--release", "--example", EXAMPLE]
     )
-    return out + err
+    combined = out + err
+    if rc != 0 and "ACCEPT" not in combined and "REJECT" not in combined:
+        print(f"    cargo run failed (rc={rc}):", file=sys.stderr)
+        print(combined, file=sys.stderr)
+    return combined
 
 
 def parse_text_size(output):
@@ -61,16 +67,16 @@ def get_text_size():
             size = parse_text_size(out)
             if size is not None:
                 return size
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print(f"    cargo-size not available: {e}", file=sys.stderr)
     # Fallback: try avr-size directly on the ELF
     elf = f"target/avr-none/release/examples/{EXAMPLE}.elf"
     try:
         rc, out, _ = run_cmd(["avr-size", "-A", elf])
         if rc == 0:
             return parse_text_size(out)
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print(f"    avr-size not available: {e}", file=sys.stderr)
     return None
 
 
@@ -110,6 +116,16 @@ def main():
     status = "ACCEPT" if result["accepted"] else "REJECT"
     print(f"    {status}", file=sys.stderr)
 
+    missing = []
+    if result["stack"] is None:
+        missing.append("stack")
+    if result["time_ms"] is None:
+        missing.append("time")
+    if text_size is None:
+        missing.append(".text size")
+    if missing:
+        print(f"    Missing metrics: {', '.join(missing)}", file=sys.stderr)
+
     # Generate markdown table
     stack = str(result["stack"]) if result["stack"] is not None else "-"
     time_ms = str(result["time_ms"]) if result["time_ms"] is not None else "-"
@@ -123,6 +139,9 @@ def main():
 
     if not result["accepted"]:
         print("\nFailure: signature REJECT", file=sys.stderr)
+        return 1
+    if missing:
+        print(f"\nFailure: missing metrics: {', '.join(missing)}", file=sys.stderr)
         return 1
     return 0
 

--- a/cortex_m_demo/run_suite.py
+++ b/cortex_m_demo/run_suite.py
@@ -27,7 +27,7 @@ def run_cmd(args, **kwargs):
 
 def build_examples(target):
     """Build all examples for a target. Returns True on success."""
-    rc, out, err = run_cmd(
+    rc, _out, err = run_cmd(
         ["cargo", "build", "--target", target, "--release", "--examples"]
     )
     if rc != 0:
@@ -39,7 +39,7 @@ def build_examples(target):
 
 def run_qemu(target, example):
     """Run an example on QEMU via cargo run. Returns stdout."""
-    rc, out, err = run_cmd(
+    _rc, out, err = run_cmd(
         ["cargo", "run", "--target", target, "--release", "--example", example]
     )
     # QEMU output may be on stdout or stderr depending on semihosting
@@ -49,27 +49,17 @@ def run_qemu(target, example):
 def get_text_size(target, example):
     """Get .text section size from the ELF using arm-none-eabi-size."""
     elf = f"target/{target}/release/examples/{example}"
-    try:
-        rc, out, _ = run_cmd(["arm-none-eabi-size", "-A", elf])
-        if rc == 0:
-            for line in out.splitlines():
-                if line.startswith(".text"):
-                    parts = line.split()
-                    if len(parts) >= 2:
-                        return int(parts[1])
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
-    # Fallback: try llvm-size
-    try:
-        rc, out, _ = run_cmd(["llvm-size", "-A", elf])
-        if rc == 0:
-            for line in out.splitlines():
-                if line.startswith(".text"):
-                    parts = line.split()
-                    if len(parts) >= 2:
-                        return int(parts[1])
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    for tool in ["arm-none-eabi-size", "llvm-size"]:
+        try:
+            rc, out, _ = run_cmd([tool, "-A", elf])
+            if rc == 0:
+                for line in out.splitlines():
+                    if line.startswith(".text"):
+                        parts = line.split()
+                        if len(parts) >= 2:
+                            return int(parts[1])
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
     return None
 
 
@@ -104,7 +94,7 @@ def main():
             try:
                 output = run_qemu(target, example)
             except subprocess.TimeoutExpired:
-                print(f"    TIMEOUT", file=sys.stderr)
+                print("    TIMEOUT", file=sys.stderr)
                 failures.append(f"Timeout: {example} on {label}")
                 continue
 

--- a/cortex_m_demo/run_suite.py
+++ b/cortex_m_demo/run_suite.py
@@ -4,7 +4,6 @@
 Generates a markdown metrics table from the results.
 """
 
-import os
 import re
 import subprocess
 import sys
@@ -47,44 +46,38 @@ def run_qemu(target, example):
     return out + err
 
 
-def find_size_tools():
-    """Return list of size tool paths to try."""
-    tools = ["arm-none-eabi-size", "llvm-size"]
-    # llvm-size from rustup llvm-tools-preview lives under the sysroot
-    try:
-        result = subprocess.run(
-            ["rustc", "--print", "sysroot"],
-            capture_output=True, text=True, timeout=10,
-        )
-        if result.returncode == 0:
-            sysroot = result.stdout.strip()
-            # Walk lib/rustlib/*/bin/ for llvm-size
-            rustlib = os.path.join(sysroot, "lib", "rustlib")
-            if os.path.isdir(rustlib):
-                for entry in os.listdir(rustlib):
-                    candidate = os.path.join(rustlib, entry, "bin", "llvm-size")
-                    if os.path.isfile(candidate):
-                        tools.append(candidate)
-                        break
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
-    return tools
+def parse_text_size(output):
+    """Parse .text size from size -A output."""
+    for line in output.splitlines():
+        if line.startswith(".text"):
+            parts = line.split()
+            if len(parts) >= 2:
+                return int(parts[1])
+    return None
 
 
 def get_text_size(target, example):
-    """Get .text section size from the ELF using arm-none-eabi-size."""
+    """Get .text section size via cargo-size, falling back to arm-none-eabi-size."""
+    # cargo-size wraps llvm-size from the toolchain
+    try:
+        rc, out, _ = run_cmd([
+            "cargo", "size", "--release", "--target", target,
+            "--example", example, "--", "-A",
+        ])
+        if rc == 0:
+            size = parse_text_size(out)
+            if size is not None:
+                return size
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    # Fallback: try arm-none-eabi-size directly on the ELF
     elf = f"target/{target}/release/examples/{example}"
-    for tool in find_size_tools():
-        try:
-            rc, out, _ = run_cmd([tool, "-A", elf])
-            if rc == 0:
-                for line in out.splitlines():
-                    if line.startswith(".text"):
-                        parts = line.split()
-                        if len(parts) >= 2:
-                            return int(parts[1])
-        except (subprocess.TimeoutExpired, FileNotFoundError):
-            pass
+    try:
+        rc, out, _ = run_cmd(["arm-none-eabi-size", "-A", elf])
+        if rc == 0:
+            return parse_text_size(out)
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
     return None
 
 

--- a/cortex_m_demo/run_suite.py
+++ b/cortex_m_demo/run_suite.py
@@ -4,6 +4,7 @@
 Generates a markdown metrics table from the results.
 """
 
+import os
 import re
 import subprocess
 import sys
@@ -46,10 +47,34 @@ def run_qemu(target, example):
     return out + err
 
 
+def find_size_tools():
+    """Return list of size tool paths to try."""
+    tools = ["arm-none-eabi-size", "llvm-size"]
+    # llvm-size from rustup llvm-tools-preview lives under the sysroot
+    try:
+        result = subprocess.run(
+            ["rustc", "--print", "sysroot"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            sysroot = result.stdout.strip()
+            # Walk lib/rustlib/*/bin/ for llvm-size
+            rustlib = os.path.join(sysroot, "lib", "rustlib")
+            if os.path.isdir(rustlib):
+                for entry in os.listdir(rustlib):
+                    candidate = os.path.join(rustlib, entry, "bin", "llvm-size")
+                    if os.path.isfile(candidate):
+                        tools.append(candidate)
+                        break
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return tools
+
+
 def get_text_size(target, example):
     """Get .text section size from the ELF using arm-none-eabi-size."""
     elf = f"target/{target}/release/examples/{example}"
-    for tool in ["arm-none-eabi-size", "llvm-size"]:
+    for tool in find_size_tools():
         try:
             rc, out, _ = run_cmd([tool, "-A", elf])
             if rc == 0:

--- a/cortex_m_demo/run_suite.py
+++ b/cortex_m_demo/run_suite.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Build and run ed25519 examples on QEMU for all Cortex-M targets.
+
+Generates a markdown metrics table from the results.
+"""
+
+import re
+import subprocess
+import sys
+
+EXAMPLES = ["ed25519_u8", "ed25519_u32"]
+TARGETS = [
+    ("thumbv6m-none-eabi", "M0"),
+    ("thumbv7m-none-eabi", "M3"),
+    ("thumbv7em-none-eabi", "M4"),
+]
+TIMEOUT = 120  # seconds per QEMU run
+
+
+def run_cmd(args, **kwargs):
+    """Run a command, return (returncode, stdout, stderr)."""
+    result = subprocess.run(
+        args, capture_output=True, text=True, timeout=TIMEOUT, **kwargs
+    )
+    return result.returncode, result.stdout, result.stderr
+
+
+def build_examples(target):
+    """Build all examples for a target. Returns True on success."""
+    rc, out, err = run_cmd(
+        ["cargo", "build", "--target", target, "--release", "--examples"]
+    )
+    if rc != 0:
+        print(f"BUILD FAILED for {target}:", file=sys.stderr)
+        print(err, file=sys.stderr)
+        return False
+    return True
+
+
+def run_qemu(target, example):
+    """Run an example on QEMU via cargo run. Returns stdout."""
+    rc, out, err = run_cmd(
+        ["cargo", "run", "--target", target, "--release", "--example", example]
+    )
+    # QEMU output may be on stdout or stderr depending on semihosting
+    return out + err
+
+
+def get_text_size(target, example):
+    """Get .text section size from the ELF using arm-none-eabi-size."""
+    elf = f"target/{target}/release/examples/{example}"
+    try:
+        rc, out, _ = run_cmd(["arm-none-eabi-size", "-A", elf])
+        if rc == 0:
+            for line in out.splitlines():
+                if line.startswith(".text"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1])
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    # Fallback: try llvm-size
+    try:
+        rc, out, _ = run_cmd(["llvm-size", "-A", elf])
+        if rc == 0:
+            for line in out.splitlines():
+                if line.startswith(".text"):
+                    parts = line.split()
+                    if len(parts) >= 2:
+                        return int(parts[1])
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        pass
+    return None
+
+
+def parse_metric(output):
+    """Parse METRIC line from QEMU output. Returns dict or None."""
+    m = re.search(
+        r"METRIC stack:(\d+) cycles:(\d+) target:(\S+) backend:(\S+)", output
+    )
+    if m:
+        return {
+            "stack": int(m.group(1)),
+            "cycles": int(m.group(2)),
+            "target": m.group(3),
+            "backend": m.group(4),
+        }
+    return None
+
+
+def main():
+    results = {}  # (example, target) -> {stack, cycles, text_size, accepted}
+    failures = []
+
+    for target, label in TARGETS:
+        print(f"Building for {target}...", file=sys.stderr)
+        if not build_examples(target):
+            failures.append(f"Build failed: {target}")
+            continue
+
+        for example in EXAMPLES:
+            key = (example, target)
+            print(f"  Running {example} on {label}...", file=sys.stderr)
+            try:
+                output = run_qemu(target, example)
+            except subprocess.TimeoutExpired:
+                print(f"    TIMEOUT", file=sys.stderr)
+                failures.append(f"Timeout: {example} on {label}")
+                continue
+
+            accepted = "ed25519 ACCEPT" in output
+            metric = parse_metric(output)
+            text_size = get_text_size(target, example)
+
+            results[key] = {
+                "accepted": accepted,
+                "stack": metric["stack"] if metric else None,
+                "cycles": metric["cycles"] if metric else None,
+                "text_size": text_size,
+            }
+
+            status = "ACCEPT" if accepted else "REJECT"
+            print(f"    {status}", file=sys.stderr)
+            if not accepted:
+                failures.append(f"REJECT: {example} on {label}")
+
+    # Generate markdown table
+    backends = {"ed25519_u8": "u8", "ed25519_u32": "u32"}
+    metrics = ["Stack (bytes)", "Cycles (k)", ".text (KiB)"]
+    target_labels = [label for _, label in TARGETS]
+
+    print()
+    print(f"| Backend | Metric | {' | '.join(target_labels)} |")
+    print(f"|---------|--------|{'|'.join(['------|'] * len(TARGETS))}")
+
+    for example in EXAMPLES:
+        backend = backends[example]
+        for metric_name in metrics:
+            cells = []
+            for target, _ in TARGETS:
+                r = results.get((example, target))
+                if r is None:
+                    cells.append("-")
+                elif metric_name == "Stack (bytes)":
+                    cells.append(str(r["stack"]) if r["stack"] is not None else "-")
+                elif metric_name == "Cycles (k)":
+                    cells.append(str(r["cycles"]) if r["cycles"] is not None else "-")
+                elif metric_name == ".text (KiB)":
+                    if r["text_size"] is not None:
+                        cells.append(f"{r['text_size'] / 1024:.1f}")
+                    else:
+                        cells.append("-")
+            print(f"| {backend} | {metric_name} | {' | '.join(cells)} |")
+
+    if failures:
+        print(f"\nFailures: {len(failures)}", file=sys.stderr)
+        for f in failures:
+            print(f"  {f}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/cortex_m_demo/run_suite.py
+++ b/cortex_m_demo/run_suite.py
@@ -4,6 +4,7 @@
 Generates a markdown metrics table from the results.
 """
 
+import json
 import re
 import subprocess
 import sys
@@ -51,38 +52,24 @@ def run_qemu(target, example):
     return combined
 
 
-def parse_text_size(output):
-    """Parse .text size from size -A output."""
-    for line in output.splitlines():
-        if line.startswith(".text"):
-            parts = line.split()
-            if len(parts) >= 2:
-                return int(parts[1])
-    return None
-
-
 def get_text_size(target, example):
-    """Get .text section size via cargo-size, falling back to arm-none-eabi-size."""
-    # cargo-size wraps llvm-size from the toolchain
+    """Get .text section size via cargo-bloat JSON output."""
     try:
-        rc, out, _ = run_cmd([
-            "cargo", "size", "--release", "--target", target,
-            "--example", example, "--", "-A",
-        ])
+        rc, out, err = run_cmd([
+            "cargo", "bloat", "--release", "--target", target,
+            "--example", example, "--message-format=json",
+        ], timeout=TIMEOUT_BUILD)
         if rc == 0:
-            size = parse_text_size(out)
-            if size is not None:
-                return size
+            # JSON is on the last line of output
+            json_line = out.strip().split('\n')[-1]
+            data = json.loads(json_line)
+            return data.get("text-section-size")
+        else:
+            print(f"    cargo-bloat failed (rc={rc}): {err.strip()}", file=sys.stderr)
     except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        print(f"    cargo-size not available: {e}", file=sys.stderr)
-    # Fallback: try arm-none-eabi-size directly on the ELF
-    elf = f"target/{target}/release/examples/{example}"
-    try:
-        rc, out, _ = run_cmd(["arm-none-eabi-size", "-A", elf])
-        if rc == 0:
-            return parse_text_size(out)
-    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
-        print(f"    arm-none-eabi-size not available: {e}", file=sys.stderr)
+        print(f"    cargo-bloat not available: {e}", file=sys.stderr)
+    except (json.JSONDecodeError, IndexError) as e:
+        print(f"    cargo-bloat JSON parse error: {e}", file=sys.stderr)
     return None
 
 

--- a/cortex_m_demo/run_suite.py
+++ b/cortex_m_demo/run_suite.py
@@ -14,13 +14,14 @@ TARGETS = [
     ("thumbv7m-none-eabi", "M3"),
     ("thumbv7em-none-eabi", "M4"),
 ]
-TIMEOUT = 120  # seconds per QEMU run
+TIMEOUT_RUN = 120  # seconds per QEMU run
+TIMEOUT_BUILD = 600  # seconds for cargo build
 
 
-def run_cmd(args, **kwargs):
+def run_cmd(args, timeout=TIMEOUT_RUN, **kwargs):
     """Run a command, return (returncode, stdout, stderr)."""
     result = subprocess.run(
-        args, capture_output=True, text=True, timeout=TIMEOUT, **kwargs
+        args, capture_output=True, text=True, timeout=timeout, **kwargs
     )
     return result.returncode, result.stdout, result.stderr
 
@@ -28,7 +29,8 @@ def run_cmd(args, **kwargs):
 def build_examples(target):
     """Build all examples for a target. Returns True on success."""
     rc, _out, err = run_cmd(
-        ["cargo", "build", "--target", target, "--release", "--examples"]
+        ["cargo", "build", "--target", target, "--release", "--examples"],
+        timeout=TIMEOUT_BUILD,
     )
     if rc != 0:
         print(f"BUILD FAILED for {target}:", file=sys.stderr)
@@ -38,12 +40,15 @@ def build_examples(target):
 
 
 def run_qemu(target, example):
-    """Run an example on QEMU via cargo run. Returns stdout."""
-    _rc, out, err = run_cmd(
+    """Run an example on QEMU via cargo run. Returns stdout+stderr."""
+    rc, out, err = run_cmd(
         ["cargo", "run", "--target", target, "--release", "--example", example]
     )
-    # QEMU output may be on stdout or stderr depending on semihosting
-    return out + err
+    combined = out + err
+    if rc != 0 and "ACCEPT" not in combined and "REJECT" not in combined:
+        print(f"    cargo run failed (rc={rc}):", file=sys.stderr)
+        print(combined, file=sys.stderr)
+    return combined
 
 
 def parse_text_size(output):
@@ -68,16 +73,16 @@ def get_text_size(target, example):
             size = parse_text_size(out)
             if size is not None:
                 return size
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print(f"    cargo-size not available: {e}", file=sys.stderr)
     # Fallback: try arm-none-eabi-size directly on the ELF
     elf = f"target/{target}/release/examples/{example}"
     try:
         rc, out, _ = run_cmd(["arm-none-eabi-size", "-A", elf])
         if rc == 0:
             return parse_text_size(out)
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        pass
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        print(f"    arm-none-eabi-size not available: {e}", file=sys.stderr)
     return None
 
 
@@ -120,6 +125,13 @@ def main():
             metric = parse_metric(output)
             text_size = get_text_size(target, example)
 
+            if not metric:
+                print(f"    METRIC line missing", file=sys.stderr)
+                failures.append(f"Missing METRIC: {example} on {label}")
+            if text_size is None:
+                print(f"    .text size unavailable", file=sys.stderr)
+                failures.append(f"Missing .text size: {example} on {label}")
+
             results[key] = {
                 "accepted": accepted,
                 "stack": metric["stack"] if metric else None,
@@ -139,7 +151,7 @@ def main():
 
     print()
     print(f"| Backend | Metric | {' | '.join(target_labels)} |")
-    print(f"|---------|--------|{'|'.join(['------|'] * len(TARGETS))}")
+    print(f"|---------|--------|{' | '.join(['------'] * len(TARGETS))} |")
 
     for example in EXAMPLES:
         backend = backends[example]


### PR DESCRIPTION
Add GitHub Actions workflows that build and run all embedded demo targets, piping markdown metrics tables to $GITHUB_STEP_SUMMARY. Add avr_demo/run_suite.py modeled on cortex_m_demo/run_suite.py. Unignore both run_suite.py files in .gitignore.

## Summary by Sourcery

Add automated CI workflows to build and run embedded AVR and Cortex-M demo targets and report their performance metrics as markdown tables.

CI:
- Introduce a Cortex-M GitHub Actions workflow that builds, runs, and measures all Cortex-M demo examples under QEMU and publishes metrics to the step summary.
- Introduce an AVR GitHub Actions workflow that builds, runs, and measures the AVR demo example under simavr and publishes metrics to the step summary.

Tests:
- Add cortex_m_demo/run_suite.py to build and execute Cortex-M ed25519 examples across multiple targets and emit a consolidated markdown metrics table.
- Add avr_demo/run_suite.py to build and execute the AVR ed25519 verification demo and emit a markdown metrics table for size and performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated AVR and Cortex‑M test suites that build examples in CI, run them in emulation, and emit Markdown metrics (code size, stack, time, cycles/ticks) with pass/fail reporting. Results are appended to CI step summaries.

* **Chores**
  * Added CI workflows to run these suites on push, pull request, manual dispatch, and weekly schedule.
  * Test runner scripts are now tracked in the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->