### PR TITLE
Expose VerifyingKey and implement `signature` traits for generic Ed25519 verifier

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -16,7 +16,7 @@ modmath = { version = "0.1.5", features = ["wide-mul"] }
 fixed-bigint = { version = "0.2.5", features=["use-unsafe"], optional=true }
 num-traits = {  version = "0.2" , default-features = false }
 hmac-sha512 = { version = "1", default-features = false, features = ["opt_size"] }
-signature = { version = "2.2", default-features = false, features = ["digest"] }
+signature = { version = "2.2", default-features = false }
 
 [features]
 default = ["std"]
@@ -26,9 +26,6 @@ fixed-bigint = ["dep:fixed-bigint"]
 fixed-bigint-u64 = ["fixed-bigint"]
 fixed-bigint-256 = ["fixed-bigint"]
 fixed-bigint-u8 = ["fixed-bigint"]
-
-[dev-dependencies]
-sha2 = { version = "0.10", default-features = false }
 
 [[bin]]
 name = "verify_baked"

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -16,6 +16,7 @@ modmath = { version = "0.1.5", features = ["wide-mul"] }
 fixed-bigint = { version = "0.2.5", features=["use-unsafe"], optional=true }
 num-traits = {  version = "0.2" , default-features = false }
 hmac-sha512 = { version = "1", default-features = false, features = ["opt_size"] }
+signature = { version = "2.2", default-features = false, features = ["digest"] }
 
 [features]
 default = ["std"]
@@ -25,6 +26,9 @@ fixed-bigint = ["dep:fixed-bigint"]
 fixed-bigint-u64 = ["fixed-bigint"]
 fixed-bigint-256 = ["fixed-bigint"]
 fixed-bigint-u8 = ["fixed-bigint"]
+
+[dev-dependencies]
+sha2 = { version = "0.10", default-features = false }
 
 [[bin]]
 name = "verify_baked"

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519_heapless"
-version = "0.0.1"
+version = "0.0.2"
 edition = "2024"
 description = "Ed25519 signature verification, generic over bigint backends"
 license = "GPL-3.0-only"

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -182,6 +182,30 @@ impl<T> From<[u8; 32]> for VerifyingKey<T> {
     }
 }
 
+impl<T> Copy for VerifyingKey<T> {}
+
+impl<T> Clone for VerifyingKey<T> {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+
+impl<T> PartialEq for VerifyingKey<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.public == other.public
+    }
+}
+
+impl<T> Eq for VerifyingKey<T> {}
+
+impl<T> core::fmt::Debug for VerifyingKey<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("VerifyingKey")
+            .field("public", &self.public)
+            .finish()
+    }
+}
+
 fn parse_signature(signature: &[u8]) -> Result<[u8; 64], signature::Error> {
     signature.try_into().map_err(|_| signature::Error::new())
 }
@@ -208,37 +232,6 @@ where
     fn verify(&self, msg: &[u8], signature: &S) -> Result<(), signature::Error> {
         let signature = parse_signature(signature.as_ref())?;
         if verify::<T>(self.public, msg, signature) {
-            Ok(())
-        } else {
-            Err(signature::Error::new())
-        }
-    }
-}
-
-impl<T, D, S> signature::DigestVerifier<D, S> for VerifyingKey<T>
-where
-    D: signature::digest::Digest,
-    S: AsRef<[u8]>,
-    T: UnsignedModularInt
-        + Copy
-        + modmath::WideMul
-        + modmath::CiosMontMul
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub,
-    for<'a> &'a T: core::ops::BitAnd<Output = T>
-        + core::ops::Rem<&'a T, Output = T>
-        + core::ops::Add<&'a T, Output = T>
-        + core::ops::Sub<T, Output = T>
-        + core::ops::Sub<&'a T, Output = T>
-        + core::ops::Mul<&'a T, Output = T>
-        + core::ops::Div<&'a T, Output = T>,
-{
-    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), signature::Error> {
-        let prehashed_msg = digest.finalize();
-        let signature = parse_signature(signature.as_ref())?;
-        if verify::<T>(self.public, prehashed_msg.as_ref(), signature) {
             Ok(())
         } else {
             Err(signature::Error::new())

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -27,6 +27,8 @@ pub(crate) mod lazy_field;
 pub(crate) mod montgomery_ctx;
 pub(crate) mod strict;
 
+use core::marker::PhantomData;
+
 /// Trait for unsigned integer types supporting modular arithmetic and byte serialization.
 ///
 /// This is the main generic constraint for Ed25519 verification.
@@ -152,3 +154,94 @@ pub const MODP_SQRT_M1_BYTES: [u8; 32] = [
 /// - `msg` — message bytes (arbitrary length)
 /// - `signature` — 64-byte Ed25519 signature
 pub use strict::verify;
+
+/// Verifying key wrapper that implements `signature` crate traits.
+pub struct VerifyingKey<T> {
+    public: [u8; 32],
+    _marker: PhantomData<T>,
+}
+
+impl<T> VerifyingKey<T> {
+    /// Construct a verifying key from raw Ed25519 public key bytes.
+    pub const fn from_bytes(public: [u8; 32]) -> Self {
+        Self {
+            public,
+            _marker: PhantomData,
+        }
+    }
+
+    /// Return the wrapped public key bytes.
+    pub const fn to_bytes(&self) -> [u8; 32] {
+        self.public
+    }
+}
+
+impl<T> From<[u8; 32]> for VerifyingKey<T> {
+    fn from(public: [u8; 32]) -> Self {
+        Self::from_bytes(public)
+    }
+}
+
+fn parse_signature(signature: &[u8]) -> Result<[u8; 64], signature::Error> {
+    signature.try_into().map_err(|_| signature::Error::new())
+}
+
+impl<T, S> signature::Verifier<S> for VerifyingKey<T>
+where
+    S: AsRef<[u8]>,
+    T: UnsignedModularInt
+        + Copy
+        + modmath::WideMul
+        + modmath::CiosMontMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub,
+    for<'a> &'a T: core::ops::BitAnd<Output = T>
+        + core::ops::Rem<&'a T, Output = T>
+        + core::ops::Add<&'a T, Output = T>
+        + core::ops::Sub<T, Output = T>
+        + core::ops::Sub<&'a T, Output = T>
+        + core::ops::Mul<&'a T, Output = T>
+        + core::ops::Div<&'a T, Output = T>,
+{
+    fn verify(&self, msg: &[u8], signature: &S) -> Result<(), signature::Error> {
+        let signature = parse_signature(signature.as_ref())?;
+        if verify::<T>(self.public, msg, signature) {
+            Ok(())
+        } else {
+            Err(signature::Error::new())
+        }
+    }
+}
+
+impl<T, D, S> signature::DigestVerifier<D, S> for VerifyingKey<T>
+where
+    D: signature::digest::Digest,
+    S: AsRef<[u8]>,
+    T: UnsignedModularInt
+        + Copy
+        + modmath::WideMul
+        + modmath::CiosMontMul
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub,
+    for<'a> &'a T: core::ops::BitAnd<Output = T>
+        + core::ops::Rem<&'a T, Output = T>
+        + core::ops::Add<&'a T, Output = T>
+        + core::ops::Sub<T, Output = T>
+        + core::ops::Sub<&'a T, Output = T>
+        + core::ops::Mul<&'a T, Output = T>
+        + core::ops::Div<&'a T, Output = T>,
+{
+    fn verify_digest(&self, digest: D, signature: &S) -> Result<(), signature::Error> {
+        let prehashed_msg = digest.finalize();
+        let signature = parse_signature(signature.as_ref())?;
+        if verify::<T>(self.public, prehashed_msg.as_ref(), signature) {
+            Ok(())
+        } else {
+            Err(signature::Error::new())
+        }
+    }
+}

--- a/ed25519/tests/signature_traits.rs
+++ b/ed25519/tests/signature_traits.rs
@@ -5,8 +5,7 @@
 #![cfg(feature = "fixed-bigint")]
 
 use ed25519_heapless::VerifyingKey;
-use sha2::Digest;
-use signature::{DigestVerifier, Verifier};
+use signature::Verifier;
 
 type T = fixed_bigint::FixedUInt<u32, 16>;
 
@@ -56,13 +55,4 @@ fn verifier_rejects_signature_with_invalid_length() {
     let signature = SigWrapper(vec![0u8; 63]);
 
     assert!(verifying_key.verify(b"", &signature).is_err());
-}
-
-#[test]
-fn digest_verifier_rejects_signature_with_invalid_length() {
-    let verifying_key = VerifyingKey::<T>::from_bytes(rfc_test1_public_key());
-    let signature = SigWrapper(vec![0u8; 63]);
-    let digest = sha2::Sha512::new();
-
-    assert!(verifying_key.verify_digest(digest, &signature).is_err());
 }

--- a/ed25519/tests/signature_traits.rs
+++ b/ed25519/tests/signature_traits.rs
@@ -1,0 +1,68 @@
+//! Integration tests for `signature` crate trait implementations.
+//!
+//! Run with: cargo test -p ed25519_heapless --features fixed-bigint
+
+#![cfg(feature = "fixed-bigint")]
+
+use ed25519_heapless::VerifyingKey;
+use sha2::Digest;
+use signature::{DigestVerifier, Verifier};
+
+type T = fixed_bigint::FixedUInt<u32, 16>;
+
+struct SigWrapper(Vec<u8>);
+
+impl AsRef<[u8]> for SigWrapper {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+fn hex_to_bytes(hex: &str) -> Vec<u8> {
+    (0..hex.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&hex[i..i + 2], 16).unwrap())
+        .collect()
+}
+
+fn hex_to_array_32(hex: &str) -> [u8; 32] {
+    let bytes = hex_to_bytes(hex);
+    let mut arr = [0u8; 32];
+    arr.copy_from_slice(&bytes);
+    arr
+}
+
+fn rfc_test1_public_key() -> [u8; 32] {
+    hex_to_array_32("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a")
+}
+
+fn rfc_test1_signature() -> Vec<u8> {
+    hex_to_bytes(
+        "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+    )
+}
+
+#[test]
+fn verifier_accepts_signature_wrapper_with_as_ref() {
+    let verifying_key = VerifyingKey::<T>::from_bytes(rfc_test1_public_key());
+    let signature = SigWrapper(rfc_test1_signature());
+
+    assert!(verifying_key.verify(b"", &signature).is_ok());
+}
+
+#[test]
+fn verifier_rejects_signature_with_invalid_length() {
+    let verifying_key = VerifyingKey::<T>::from_bytes(rfc_test1_public_key());
+    let signature = SigWrapper(vec![0u8; 63]);
+
+    assert!(verifying_key.verify(b"", &signature).is_err());
+}
+
+#[test]
+fn digest_verifier_rejects_signature_with_invalid_length() {
+    let verifying_key = VerifyingKey::<T>::from_bytes(rfc_test1_public_key());
+    let signature = SigWrapper(vec![0u8; 63]);
+    let digest = sha2::Sha512::new();
+
+    assert!(verifying_key.verify_digest(digest, &signature).is_err());
+}


### PR DESCRIPTION
### Motivation

- Integrate the crate with the ecosystem `signature` traits so callers can use the verifier via standard `Verifier`/`DigestVerifier` APIs.
- Provide a small, generic wrapper that works with the existing bigint backends (e.g., `fixed-bigint`) without changing the underlying verification logic.
- Add tests to ensure the trait implementations behave correctly with typical inputs and invalid lengths.

### Description

- Added the `signature = { version = "2.2", default-features = false, features = ["digest"] }` dependency and a `sha2` `dev-dependency` in `ed25519/Cargo.toml`.
- Introduced `VerifyingKey<T>` wrapper with `from_bytes`/`to_bytes` and `From<[u8; 32]>` conversion in `ed25519/src/lib.rs` to hold raw public key bytes and a `PhantomData` for the bigint backend.
- Implemented `signature::Verifier` and `signature::DigestVerifier` for `VerifyingKey<T>` delegating to the existing `verify::<T>` function and added a `parse_signature` helper to validate signature length.
- Added integration tests in `ed25519/tests/signature_traits.rs` that exercise the trait implementations with a `fixed-bigint` backend, including an RFC test vector and invalid-length checks.

### Testing

- Ran `cargo test -p ed25519_heapless --features fixed-bigint` which executed the `signature_traits` integration tests and they passed.
- The test suite asserts that a valid RFC test vector verifies successfully and that invalid-length signatures are rejected by both `Verifier` and `DigestVerifier` implementations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ba502fa1b08331b74186e8851e4ac1)

## Summary by Sourcery

Integrate the ed25519 verifier with the `signature` crate by introducing a generic verifying key wrapper and corresponding trait implementations, and add tests to validate them.

New Features:
- Add a generic `VerifyingKey<T>` type to represent Ed25519 public keys and support conversion to and from raw bytes.
- Implement `signature::Verifier` and `signature::DigestVerifier` traits for `VerifyingKey<T>` to enable use with standard signature verification APIs.

Enhancements:
- Introduce a helper for validating Ed25519 signature lengths before verification to provide consistent error handling.

Build:
- Add the `signature` crate as a dependency and `sha2` as a dev-dependency in the ed25519 crate.

Tests:
- Add integration tests exercising the `signature` trait implementations with a fixed-bigint backend, including RFC test vector verification and invalid-length signature rejection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a generic VerifyingKey type to enable signature verification for public keys, with byte conversion helpers and standard verification behavior (produces clear errors for invalid signatures).
* **Tests**
  * Added integration tests covering successful verification and failure cases (including invalid/short signatures).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->