### PR TITLE
Migrate to modmath 0.3 with ZeroizeOnDrop on Residue

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,9 @@ repos:
     -   id: fmt
         name: Fmt for ed25519_heapless
         args: ['--manifest-path=ed25519/Cargo.toml', '--']
+    -   id: cargo-check
+        name: Cargo-check for ed25519_heapless
+        args: ['--manifest-path=ed25519/Cargo.toml', '--features=fixed-bigint,sha512-hmac-sha512']
+    -   id: clippy
+        name: Clippy for ed25519_heapless
+        args: ['--manifest-path=ed25519/Cargo.toml', '--features=fixed-bigint,sha512-hmac-sha512', '--', '-D', 'warnings']

--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["cryptography", "no-std", "no-std::no-alloc"]
 [dependencies]
 log = { version = "0.4", optional = true }
 env_logger = { version = "0.11", optional = true }
-modmath = { version = "0.2", features = ["wide-mul"] }
-fixed-bigint = { version = "0.3", features=["use-unsafe"], optional=true }
+modmath = { version = "0.3", features = ["wide-mul", "zeroize"] }
+fixed-bigint = { version = "0.3", features=["use-unsafe", "zeroize"], optional=true }
 subtle = { version = "2.6", default-features = false }
 num-traits = {  version = "0.2" , default-features = false }
 zeroize = { version = "1.8", default-features = false }

--- a/ed25519/src/curve25519_field.rs
+++ b/ed25519/src/curve25519_field.rs
@@ -55,7 +55,8 @@ where
         + num_traits::WrappingSub
         + Parity
         + WideMul
-        + CiosMontMul,
+        + CiosMontMul
+        + modmath::MontStorage,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     pub fn new(modulus: T) -> Option<Self> {
@@ -119,8 +120,8 @@ where
     /// the same 2-p slack); otherwise straight subtract.
     #[inline]
     pub fn sub<'f>(&'f self, a: &ResidueNct<'f, T>, b: &ResidueNct<'f, T>) -> ResidueNct<'f, T> {
-        let a_m = (*a).mont_value();
-        let b_m = (*b).mont_value();
+        let a_m = *(*a).mont_value();
+        let b_m = *(*b).mont_value();
         let diff = if a_m >= b_m {
             a_m - b_m
         } else {
@@ -174,7 +175,8 @@ where
         + WideMul
         + CiosMontMulCt
         + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+        + subtle::ConstantTimeLess
+        + modmath::MontStorage,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     pub fn new(modulus: T) -> Option<Self> {
@@ -238,8 +240,8 @@ where
     /// design.
     #[inline]
     pub fn sub<'f>(&'f self, a: &ResidueCt<'f, T>, b: &ResidueCt<'f, T>) -> ResidueCt<'f, T> {
-        let a_m = (*a).mont_value();
-        let b_m = (*b).mont_value();
+        let a_m = *(*a).mont_value();
+        let b_m = *(*b).mont_value();
         let diff_no_borrow = a_m - b_m;
         let diff_with_borrow = (a_m + self.modulus) - b_m;
         let needs_add_p = a_m.ct_lt(&b_m);
@@ -378,17 +380,17 @@ mod tests {
         // underflows. Must not panic.
         let added = fct.add(&small, &smaller);
         // Result Montgomery value should equal 8 (no reduction needed).
-        assert_eq!(added.mont_value(), T256Ct::from(8u8));
+        assert_eq!(*added.mont_value(), T256Ct::from(8u8));
 
         // sub path: a - b = 5 - 3 = 2, no borrow case. Also exercise
         // the borrow path directly.
         let subbed = fct.sub(&small, &smaller);
-        assert_eq!(subbed.mont_value(), T256Ct::from(2u8));
+        assert_eq!(*subbed.mont_value(), T256Ct::from(2u8));
 
         let borrow = fct.sub(&smaller, &small); // 3 - 5 → borrow path
         // Result = p + 3 - 5 = p - 2 (in Montgomery form).
         let p: T256Ct = T256Ct::from_le_bytes(&P_BYTES);
         let expected = p - T256Ct::from(2u8);
-        assert_eq!(borrow.mont_value(), expected);
+        assert_eq!(*borrow.mont_value(), expected);
     }
 }

--- a/ed25519/src/curve25519_field.rs
+++ b/ed25519/src/curve25519_field.rs
@@ -223,14 +223,24 @@ where
     /// test for the regression guard.
     #[inline]
     pub fn add<'f>(&'f self, a: &ResidueCt<'f, T>, b: &ResidueCt<'f, T>) -> ResidueCt<'f, T> {
-        let a_m = (*a).mont_value();
-        let b_m = (*b).mont_value();
-        let sum = a_m + b_m;
-        let reduced = sum - self.modulus;
+        // Stay in `&T` for the secret-derived operands so no implicit
+        // `T: Copy` materializations land on the stack; every owned
+        // intermediate gets wrapped in `Zeroizing<T>` so its bytes are
+        // wiped at scope end (`FixedUInt` is `Copy + Zeroize`, but
+        // `Copy` is mutually exclusive with `Drop`, so the bare `T`
+        // locals would otherwise sit on the stack until overwritten).
+        let a_m = a.mont_value();
+        let b_m = b.mont_value();
+        let sum = zeroize::Zeroizing::new(a_m + b_m);
+        let reduced = zeroize::Zeroizing::new(&*sum - &self.modulus);
         // sum < modulus  →  keep sum;  otherwise → use sum − modulus.
         let needs_reduce = !sum.ct_lt(&self.modulus);
-        let result = T::conditional_select(&sum, &reduced, needs_reduce);
-        self.inner.residue_from_mont(result)
+        let result = zeroize::Zeroizing::new(T::conditional_select(&*sum, &*reduced, needs_reduce));
+        // The deref-copy into `residue_from_mont` materializes one bare
+        // `T` briefly during the call — but the new `ResidueCt` is
+        // `ZeroizeOnDrop`, so the bytes land inside a wiped allocation
+        // immediately. Our local `result` is also wiped on drop.
+        self.inner.residue_from_mont(*result)
     }
 
     /// CT lazy sub: compute both `a − b` (mod 2^W) and `a + modulus − b`,
@@ -240,13 +250,21 @@ where
     /// design.
     #[inline]
     pub fn sub<'f>(&'f self, a: &ResidueCt<'f, T>, b: &ResidueCt<'f, T>) -> ResidueCt<'f, T> {
-        let a_m = *(*a).mont_value();
-        let b_m = *(*b).mont_value();
-        let diff_no_borrow = a_m - b_m;
-        let diff_with_borrow = (a_m + self.modulus) - b_m;
-        let needs_add_p = a_m.ct_lt(&b_m);
-        let result = T::conditional_select(&diff_no_borrow, &diff_with_borrow, needs_add_p);
-        self.inner.residue_from_mont(result)
+        // Same wrap-everything-in-`Zeroizing` discipline as [`Self::add`].
+        let a_m = a.mont_value();
+        let b_m = b.mont_value();
+        let diff_no_borrow = zeroize::Zeroizing::new(a_m - b_m);
+        let diff_with_borrow = zeroize::Zeroizing::new({
+            let with_modulus = zeroize::Zeroizing::new(a_m + &self.modulus);
+            &*with_modulus - b_m
+        });
+        let needs_add_p = a_m.ct_lt(b_m);
+        let result = zeroize::Zeroizing::new(T::conditional_select(
+            &*diff_no_borrow,
+            &*diff_with_borrow,
+            needs_add_p,
+        ));
+        self.inner.residue_from_mont(*result)
     }
 
     /// CT Fermat inverse: `a^{-1} mod p = a^{p − 2} mod p`. The exponent

--- a/ed25519/src/curve25519_field.rs
+++ b/ed25519/src/curve25519_field.rs
@@ -232,6 +232,13 @@ where
         let a_m = a.mont_value();
         let b_m = b.mont_value();
         let sum = zeroize::Zeroizing::new(a_m + b_m);
+        // The `&*sum` / `&self.modulus` refs look needlessly taken to
+        // clippy's `op_ref` lint, which would suggest
+        // `*sum - self.modulus`. Don't take that suggestion: `*sum`
+        // is a deref-copy of `T` out of `Zeroizing<T>` into a bare
+        // stack slot with no `Drop`, re-introducing the very leak
+        // this function plugs.
+        #[allow(clippy::op_ref)]
         let reduced = zeroize::Zeroizing::new(&*sum - &self.modulus);
         // sum < modulus  →  keep sum;  otherwise → use sum − modulus.
         let needs_reduce = !sum.ct_lt(&self.modulus);

--- a/ed25519/src/curve25519_field.rs
+++ b/ed25519/src/curve25519_field.rs
@@ -120,8 +120,8 @@ where
     /// the same 2-p slack); otherwise straight subtract.
     #[inline]
     pub fn sub<'f>(&'f self, a: &ResidueNct<'f, T>, b: &ResidueNct<'f, T>) -> ResidueNct<'f, T> {
-        let a_m = *(*a).mont_value();
-        let b_m = *(*b).mont_value();
+        let a_m = *a.mont_value();
+        let b_m = *b.mont_value();
         let diff = if a_m >= b_m {
             a_m - b_m
         } else {

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -69,6 +69,7 @@ pub trait UnsignedModularInt:
     + core::ops::Add<Output = Self>
     + core::ops::BitAnd<Output = Self>
     + core::ops::ShrAssign<usize>
+    + modmath::MontStorage
 {
     /// Deserialize from little-endian bytes. Reads up to the type's width from `bytes`.
     fn from_bytes_le(bytes: &[u8]) -> Self;

--- a/ed25519/src/strict.rs
+++ b/ed25519/src/strict.rs
@@ -290,13 +290,12 @@ where
         + num_traits::WrappingSub,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
-    let &(y_plus_x, y_minus_x, two_dt) = niels;
     // A = (Y₁−X₁)·(y−x); B = (Y₁+X₁)·(y+x); C = T₁·2dt; D = 2·Z₁
     let pp_y_minus_x = field.sub(&pp.1, &pp.0);
-    let a = field.mul(&pp_y_minus_x, &y_minus_x);
+    let a = field.mul(&pp_y_minus_x, &niels.1);
     let pp_y_plus_x = field.add(&pp.1, &pp.0);
-    let b = field.mul(&pp_y_plus_x, &y_plus_x);
-    let c = field.mul(&pp.3, &two_dt);
+    let b = field.mul(&pp_y_plus_x, &niels.0);
+    let c = field.mul(&pp.3, &niels.2);
     let d = field.add(&pp.2, &pp.2);
     // E = B − A; F = D − C; G = D + C; H = B + A
     let e = field.sub(&b, &a);
@@ -363,15 +362,22 @@ where
     let naf = crate::jsf::NafIterator::new(s, h);
 
     // Identity in extended-twisted Edwards: (0, 1, 1, 0).
-    let one = field.one();
     let zero = field.zero();
-    let mut result: EdPoint<'f, T> = (zero, one, one, zero);
+    let mut result: EdPoint<'f, T> = (field.zero(), field.one(), field.one(), field.zero());
 
     // Precompute Niels form of base points + their negations.
     let g_niels = to_niels(g, d_raw, field);
     let a_niels = to_niels(a, d_raw, field);
-    let neg_g_niels = (g_niels.1, g_niels.0, field.sub(&zero, &g_niels.2));
-    let neg_a_niels = (a_niels.1, a_niels.0, field.sub(&zero, &a_niels.2));
+    let neg_g_niels = (
+        g_niels.1.clone(),
+        g_niels.0.clone(),
+        field.sub(&zero, &g_niels.2),
+    );
+    let neg_a_niels = (
+        a_niels.1.clone(),
+        a_niels.0.clone(),
+        field.sub(&zero, &a_niels.2),
+    );
 
     for digit in naf.digits_msb_first() {
         result = point_double(&result, field);

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -205,7 +205,13 @@ where
     // All CT — z2 is secret-derived.
     let z2_inv = field.inv(&z2);
     let result_res = field.mul(&x2, &z2_inv);
-    let result = field.into_raw(&result_res);
+    // Wrap the owned `T` returned by `into_raw` in `Zeroizing` so the
+    // shared-secret bytes don't sit on the stack after this function
+    // returns. `T` is `Copy` (precluding `ZeroizeOnDrop` directly), but
+    // `T: zeroize::Zeroize` is implied by `UnsignedModularInt`'s
+    // `MontStorage` supertrait when modmath's `zeroize` feature is on
+    // — which we require — so `Zeroizing<T>` works without extra bounds.
+    let result = zeroize::Zeroizing::new(field.into_raw(&result_res));
 
     // T can be wider than 32 bytes (e.g. FixedUInt<u32, 16> is 64 bytes). The
     // MAX_T_BYTES guard above bounds the scratch size; copy out the low 32

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -152,11 +152,10 @@ where
     // Initial ladder state:
     //   (x2, z2) = (1, 0)   -- point at infinity
     //   (x3, z3) = (u, 1)   -- the input point
-    let one = field.one();
-    let mut x2 = one;
+    let mut x2 = field.one();
     let mut z2 = field.zero();
-    let mut x3 = x1;
-    let mut z3 = one;
+    let mut x3 = x1.clone();
+    let mut z3 = field.one();
     let mut swap: u8 = 0;
 
     // Process scalar bits 254..=0 (255 iterations). The conditional swap is
@@ -211,8 +210,8 @@ where
     // T can be wider than 32 bytes (e.g. FixedUInt<u32, 16> is 64 bytes). The
     // MAX_T_BYTES guard above bounds the scratch size; copy out the low 32
     // bytes — the field element is < p < 2^255 so the high half is zero.
-    let mut scratch = [0u8; MAX_T_BYTES];
-    let bytes = result.to_bytes_le(&mut scratch);
+    let mut scratch = zeroize::Zeroizing::new([0u8; MAX_T_BYTES]);
+    let bytes = result.to_bytes_le(&mut *scratch);
     let mut out = [0u8; 32];
     out.copy_from_slice(&bytes[..32]);
     out


### PR DESCRIPTION
modmath 0.3.0 drops Copy from Residue and adds optional zeroize support gated on a "zeroize" cargo feature. Both changes harden the constant-time path:

- !Copy + ZeroizeOnDrop on ResidueCt means every ladder intermediate auto-wipes its 32-byte Montgomery buffer at scope end, plugging the "stack still holds secret-derived bits after x25519 returns" leak that Zeroizing<scalar> alone did not cover.
- The Copy drop forces move semantics on secrets — every implicit copy was a fresh stack location that nothing would ever wipe.

## Summary by Sourcery

Migrate the Ed25519/X25519 field arithmetic to modmath 0.3 with secure Montgomery storage and zeroizing scratch buffers, tightening constant-time scalar multiplication handling of secret data.

New Features:
- Enable zeroize-backed Montgomery storage for constant-time Curve25519 field residues and scratch buffers.

Bug Fixes:
- Fix misuse of Niels coordinate references that relied on now-removed Copy semantics in strict Ed25519 operations.
- Eliminate lingering secret-derived data in X25519 ladder intermediates and output scratch buffers by enforcing moves and zeroizing storage.

Enhancements:
- Update modular arithmetic traits and bounds to use the new MontStorage API from modmath 0.3.
- Adjust field subtraction and tests to account for Residue types no longer being Copy.

Build:
- Bump modmath to 0.3 with wide-mul and zeroize features and align fixed-bigint to 0.3 with zeroize support.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependencies and enabled secure zeroization features; adjusted pre-commit hooks to run with the new feature set.
* **Refactor**
  * Tightened backend compatibility and internal arithmetic to improve correctness.
  * Reworked algorithms to zeroize intermediate buffers and temporaries, enhancing secret-data handling and memory hygiene.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->