### PR TITLE
Add Wycheproof conformance tests for x25519 and ed25519

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -21,6 +21,9 @@ hmac-sha512 = { version = "1", default-features = false, features = ["opt_size"]
 sha2 = { version = "0.10", default-features = false, features = ["force-soft-compact"], optional = true }
 signature = { version = "2.2", default-features = false }
 
+[dev-dependencies]
+wycheproof = { version = "0.6", default-features = false, features = ["xdh", "eddsa"] }
+
 [features]
 default = ["std", "sha512-hmac-sha512"]
 std = ["log", "env_logger"]

--- a/ed25519/tests/wycheproof_ed25519.rs
+++ b/ed25519/tests/wycheproof_ed25519.rs
@@ -1,0 +1,94 @@
+//! Wycheproof Ed25519 verification conformance test.
+//!
+//! Source: <https://github.com/randombit/wycheproof-rs>. Dev-dep only.
+//!
+//! We use the non-CT backend for verify (public-input operation, no
+//! secret-handling) — `FixedUInt<u32, 16, Nct>`. The `verify` entry
+//! point in `strict.rs` returns `bool`, so the test logic is:
+//!
+//! * `TestResult::Valid` → must return `true`.
+//! * `TestResult::Invalid` → must return `false`.
+//! * `TestResult::Acceptable` → either is OK; informational only.
+//!
+//! Vectors with the wrong signature length (Wycheproof carries truncated
+//! and oversize signatures, flagged TruncatedSignature etc.) can't be
+//! fed to our 64-byte-array API. Those are treated as "rejected before
+//! verify" which matches the expected `Invalid` outcome — counted as
+//! `rejected_at_parse` rather than skipped.
+
+#![cfg(all(feature = "fixed-bigint", feature = "sha512-hmac-sha512"))]
+
+use ed25519_heapless::verify;
+use fixed_bigint::{FixedUInt, Nct};
+use wycheproof::TestResult;
+
+type T = FixedUInt<u32, 16, Nct>;
+
+#[test]
+fn wycheproof_ed25519() {
+    let set = wycheproof::eddsa::TestSet::load(wycheproof::eddsa::TestName::Ed25519)
+        .expect("wycheproof Ed25519 corpus failed to load");
+
+    let mut ran = 0usize;
+    let mut rejected_at_parse = 0usize;
+    let mut failures = 0usize;
+
+    for group in &set.test_groups {
+        let public_key: [u8; 32] = match group.key.pk.as_ref().try_into() {
+            Ok(b) => b,
+            Err(_) => {
+                eprintln!("skipping group: public key length != 32");
+                continue;
+            }
+        };
+
+        for tc in &group.tests {
+            let msg = tc.msg.as_ref();
+
+            // Wycheproof Ed25519 signatures are mostly 64 bytes; the
+            // truncated/garbage variants are flagged Invalid. If we
+            // can't parse the length, we know we'd reject — verify the
+            // expectation says the same.
+            let sig: [u8; 64] = match tc.sig.as_ref().try_into() {
+                Ok(b) => b,
+                Err(_) => {
+                    rejected_at_parse += 1;
+                    if !tc.result.must_fail() {
+                        eprintln!(
+                            "tcId {} ({:?}) flags={:?}: rejected at parse but Wycheproof says {:?}",
+                            tc.tc_id, tc.comment, tc.flags, tc.result
+                        );
+                        failures += 1;
+                    }
+                    continue;
+                }
+            };
+
+            let ok = verify::<T>(public_key, msg, sig);
+            ran += 1;
+
+            let outcome_matches = match tc.result {
+                TestResult::Valid => ok,
+                TestResult::Invalid => !ok,
+                TestResult::Acceptable => true,
+            };
+
+            if !outcome_matches {
+                eprintln!(
+                    "tcId {} ({:?}) flags={:?} result={:?}: verify returned {}",
+                    tc.tc_id, tc.comment, tc.flags, tc.result, ok
+                );
+                failures += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "wycheproof Ed25519: ran={ran} rejected_at_parse={rejected_at_parse} failed={failures}"
+    );
+    assert!(ran > 0, "no Wycheproof Ed25519 vectors executed");
+    assert_eq!(
+        failures, 0,
+        "{failures} Wycheproof Ed25519 vectors mismatched"
+    );
+}

--- a/ed25519/tests/wycheproof_ed25519.rs
+++ b/ed25519/tests/wycheproof_ed25519.rs
@@ -16,7 +16,10 @@
 //! verify" which matches the expected `Invalid` outcome — counted as
 //! `rejected_at_parse` rather than skipped.
 
-#![cfg(all(feature = "fixed-bigint", feature = "sha512-hmac-sha512"))]
+#![cfg(all(
+    feature = "fixed-bigint",
+    any(feature = "sha512-hmac-sha512", feature = "sha512-sha2")
+))]
 
 use ed25519_heapless::verify;
 use fixed_bigint::{FixedUInt, Nct};
@@ -37,7 +40,19 @@ fn wycheproof_ed25519() {
         let public_key: [u8; 32] = match group.key.pk.as_ref().try_into() {
             Ok(b) => b,
             Err(_) => {
+                // The fixed [u8; 32] API can't represent this group's
+                // public key. Don't silently lose the group's tests —
+                // any Valid / Acceptable case here is a real gap.
                 eprintln!("skipping group: public key length != 32");
+                for tc in &group.tests {
+                    if !tc.result.must_fail() {
+                        eprintln!(
+                            "tcId {} ({:?}) in skipped group: pk length != 32 but Wycheproof says {:?}",
+                            tc.tc_id, tc.comment, tc.result
+                        );
+                        failures += 1;
+                    }
+                }
                 continue;
             }
         };

--- a/ed25519/tests/wycheproof_x25519.rs
+++ b/ed25519/tests/wycheproof_x25519.rs
@@ -1,0 +1,72 @@
+//! Wycheproof X25519 conformance test (Project Wycheproof v1 corpus).
+//!
+//! Source: <https://github.com/randombit/wycheproof-rs> — vendors the
+//! upstream JSON vectors as a Rust crate (dev-dep only).
+//!
+//! Coverage matters for X25519 because RFC 7748 §5 says implementations
+//! are *not required* to reject low-order points or twist points — but if
+//! they accept them, the output of the scalar multiplication must equal
+//! the value Wycheproof specifies. Our `x25519::x25519` always computes
+//! (no input rejection), so we always compare against `shared_secret`.
+
+#![cfg(feature = "fixed-bigint")]
+
+use ed25519_heapless::x25519;
+use fixed_bigint::{Ct, FixedUInt};
+
+type T = FixedUInt<u32, 16, Ct>;
+
+#[test]
+fn wycheproof_x25519() {
+    let set = wycheproof::xdh::TestSet::load(wycheproof::xdh::TestName::X25519)
+        .expect("wycheproof X25519 corpus failed to load");
+
+    let mut ran = 0usize;
+    let mut skipped = 0usize;
+    let mut failures = 0usize;
+
+    for group in &set.test_groups {
+        for tc in &group.tests {
+            // X25519 takes a fixed 32-byte private scalar and 32-byte
+            // peer u-coordinate. Wycheproof carries some malformed-length
+            // public keys (flagged PublicKeyTooLong) which we can't even
+            // feed to our API — count those as skipped, not failed.
+            let priv_bytes: [u8; 32] = match tc.private_key.as_ref().try_into() {
+                Ok(b) => b,
+                Err(_) => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+            let pub_bytes: [u8; 32] = match tc.public_key.as_ref().try_into() {
+                Ok(b) => b,
+                Err(_) => {
+                    skipped += 1;
+                    continue;
+                }
+            };
+            let expected: [u8; 32] = tc
+                .shared_secret
+                .as_ref()
+                .try_into()
+                .expect("Wycheproof shared_secret should always be 32 bytes for X25519");
+
+            let got = x25519::<T>(&priv_bytes, &pub_bytes);
+            ran += 1;
+            if got != expected {
+                eprintln!(
+                    "tcId {} ({:?}) flags={:?} result={:?}: expected {:02x?} got {:02x?}",
+                    tc.tc_id, tc.comment, tc.flags, tc.result, expected, got
+                );
+                failures += 1;
+            }
+        }
+    }
+
+    eprintln!("wycheproof X25519: ran={ran} skipped={skipped} failed={failures}");
+    assert!(ran > 0, "no Wycheproof X25519 vectors executed");
+    assert_eq!(
+        failures, 0,
+        "{failures} Wycheproof X25519 vectors mismatched"
+    );
+}

--- a/ed25519/tests/wycheproof_x25519.rs
+++ b/ed25519/tests/wycheproof_x25519.rs
@@ -34,6 +34,15 @@ fn wycheproof_x25519() {
             let priv_bytes: [u8; 32] = match tc.private_key.as_ref().try_into() {
                 Ok(b) => b,
                 Err(_) => {
+                    // Length mismatch on a Valid / Acceptable case is a
+                    // silent test gap, not a legitimate skip.
+                    if !tc.result.must_fail() {
+                        eprintln!(
+                            "tcId {} ({:?}) flags={:?}: private key rejected at parse but Wycheproof says {:?}",
+                            tc.tc_id, tc.comment, tc.flags, tc.result
+                        );
+                        failures += 1;
+                    }
                     skipped += 1;
                     continue;
                 }
@@ -41,6 +50,13 @@ fn wycheproof_x25519() {
             let pub_bytes: [u8; 32] = match tc.public_key.as_ref().try_into() {
                 Ok(b) => b,
                 Err(_) => {
+                    if !tc.result.must_fail() {
+                        eprintln!(
+                            "tcId {} ({:?}) flags={:?}: public key rejected at parse but Wycheproof says {:?}",
+                            tc.tc_id, tc.comment, tc.flags, tc.result
+                        );
+                        failures += 1;
+                    }
                     skipped += 1;
                     continue;
                 }


### PR DESCRIPTION
Wire up Project Wycheproof's test corpora via the `wycheproof` crate (dev-dep only — no runtime impact, no production dependency).

## Summary by Sourcery

Add Wycheproof-based conformance testing for Ed25519 verification and X25519 key agreement using dev-only test corpora.

Tests:
- Introduce Wycheproof Ed25519 verification tests gated on fixed-bigint and SHA-512 HMAC features.
- Add Wycheproof X25519 conformance tests that validate scalar multiplication outputs against official vectors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added Wycheproof conformance test suites for Ed25519 signature verification and X25519 key agreement using official test vectors; tests validate parsing, execution, and expected outcomes with diagnostic reporting.
* **Chores**
  * Added the Wycheproof crate as a development dependency to enable the new conformance tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->