### PR TITLE
Add scalar blinding for X25519

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -20,9 +20,11 @@ zeroize = { version = "1.8", default-features = false }
 hmac-sha512 = { version = "1", default-features = false, features = ["opt_size"], optional = true }
 sha2 = { version = "0.10", default-features = false, features = ["force-soft-compact"], optional = true }
 signature = { version = "2.2", default-features = false }
+rand_core = { version = "0.9", default-features = false }
 
 [dev-dependencies]
 wycheproof = { version = "0.6", default-features = false, features = ["xdh", "eddsa"] }
+rand_chacha = { version = "0.9", default-features = false }
 
 [features]
 default = ["std", "sha512-hmac-sha512"]

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -175,8 +175,8 @@ pub use strict::{verify, verify_with_field};
 /// before the ladder runs, so callers do not need to pre-process either
 /// input.
 pub use x25519::{
-    A24_BYTES, BASE_U_BYTES, GROUP_ORDER_BYTES, clamp, x25519, x25519_base, x25519_base_blinded,
-    x25519_blinded,
+    A24_BYTES, BASE_U_BYTES, BLINDING_MODULUS_BYTES, clamp, x25519, x25519_base,
+    x25519_base_blinded, x25519_blinded,
 };
 
 /// Verifying key wrapper that implements `signature` crate traits.

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -174,7 +174,10 @@ pub use strict::{verify, verify_with_field};
 /// is clamped per RFC 7748 and the high bit of `u_in[31]` is masked off
 /// before the ladder runs, so callers do not need to pre-process either
 /// input.
-pub use x25519::{A24_BYTES, BASE_U_BYTES, clamp, x25519, x25519_base};
+pub use x25519::{
+    A24_BYTES, BASE_U_BYTES, GROUP_ORDER_BYTES, clamp, x25519, x25519_base, x25519_base_blinded,
+    x25519_blinded,
+};
 
 /// Verifying key wrapper that implements `signature` crate traits.
 pub struct VerifyingKey<T> {

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -34,17 +34,18 @@ pub const BASE_U_BYTES: [u8; 32] = [
     9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
-/// Full curve group order `8·ℓ`, used as the scalar-blinding modulus.
-///
-/// `ℓ` alone would not work: `ℓ mod 8 = 5`, so `r·ℓ` is not a multiple
-/// of 8 in general, which would break the RFC 7748 clamp invariant
-/// (clamped scalars must be multiples of 8 to clear cofactor torsion).
-/// `8·ℓ` is always a multiple of 8 and annihilates any point on the
-/// curve. Twist points are not annihilated — blinded results may
-/// diverge from unblinded for twist u-coords.
-pub const GROUP_ORDER_BYTES: [u8; 32] = [
-    0x68, 0x9f, 0xae, 0xe7, 0xd2, 0x18, 0x93, 0xc0, 0xb2, 0xe6, 0xbc, 0x17, 0xf5, 0xce, 0xf7, 0xa6,
-    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+/// Universal blinding modulus: `lcm(curve_order, twist_order) = 8·ℓ·ℓ'`
+/// where `ℓ` is the curve subgroup order and `ℓ'` is the twist
+/// subgroup order. Annihilates every point on Curve25519 *and* its
+/// twist, so the blinded path matches the unblinded path for every
+/// 32-byte u-coordinate the X25519 ladder accepts. `8·ℓ` alone would
+/// only work for curve points; using the LCM costs ~2× ladder
+/// iterations but eliminates the twist-conformance gap.
+pub const BLINDING_MODULUS_BYTES: [u8; 64] = [
+    0xc8, 0xce, 0xb3, 0x29, 0x3b, 0xb8, 0xf4, 0x0b, 0xd9, 0xb1, 0xd1, 0x00, 0x00, 0x92, 0x10, 0xa1,
+    0x13, 0xa4, 0x80, 0xde, 0xc2, 0x38, 0x11, 0x23, 0x5c, 0xf6, 0x3c, 0x48, 0xee, 0x6b, 0xc6, 0x64,
+    0xfb, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0x0f,
 ];
 
 /// Backends wider than this are rejected at runtime. 64 bytes covers all
@@ -52,8 +53,9 @@ pub const GROUP_ORDER_BYTES: [u8; 32] = [
 /// bounds the scratch buffers below.
 const MAX_T_BYTES: usize = 64;
 
-/// `k + r·(8·ℓ)` fits in 36 bytes for a 32-bit blinder `r`.
-const BLINDED_SCALAR_BYTES: usize = 36;
+/// `k + r·(8·ℓ·ℓ')` fits in 68 bytes for a 32-bit blinder `r`
+/// (worst case 540 bits).
+const BLINDED_SCALAR_BYTES: usize = 68;
 
 const BLINDED_BIT_COUNT: usize = BLINDED_SCALAR_BYTES * 8;
 
@@ -66,19 +68,22 @@ pub const fn clamp(mut k: [u8; 32]) -> [u8; 32] {
     k
 }
 
-/// Compute `k' = k + r·(8·ℓ)` little-endian. Schoolbook in
+/// Compute `k' = k + r·(8·ℓ·ℓ')` little-endian. Schoolbook in
 /// `u8`/`u16`/`u64` to avoid dragging in a wider `FixedUInt`.
-fn compute_blinded_scalar(k_clamped: &[u8; 32], r: u32) -> [u8; BLINDED_SCALAR_BYTES] {
-    let mut out = [0u8; BLINDED_SCALAR_BYTES];
+fn compute_blinded_scalar(
+    k_clamped: &[u8; 32],
+    r: u32,
+) -> zeroize::Zeroizing<[u8; BLINDED_SCALAR_BYTES]> {
+    let mut out = zeroize::Zeroizing::new([0u8; BLINDED_SCALAR_BYTES]);
     let r = r as u64;
 
     let mut carry: u64 = 0;
-    for i in 0..32 {
-        let prod = r * (GROUP_ORDER_BYTES[i] as u64) + carry;
+    for i in 0..64 {
+        let prod = r * (BLINDING_MODULUS_BYTES[i] as u64) + carry;
         out[i] = prod as u8;
         carry = prod >> 8;
     }
-    for byte in out.iter_mut().skip(32) {
+    for byte in out.iter_mut().skip(64) {
         carry += *byte as u64;
         *byte = carry as u8;
         carry >>= 8;
@@ -230,9 +235,9 @@ where
 }
 
 /// X25519 shared secret with scalar blinding: replaces `k` with
-/// `k' = k + r·(8·ℓ)` for a fresh 32-bit `r`. Output equals
-/// [`x25519`] for any curve-subgroup `u_in`; twist-point inputs may
-/// diverge — see [`GROUP_ORDER_BYTES`].
+/// `k' = k + r·(8·ℓ·ℓ')` for a fresh 32-bit `r`. Output equals
+/// [`x25519`] for every accepted u-coordinate, curve or twist —
+/// see [`BLINDING_MODULUS_BYTES`].
 ///
 /// Defends against multi-trace DPA aggregation on a long-lived secret
 /// scalar. For single-trace correlation, combine with projective
@@ -243,7 +248,7 @@ where
 /// blinding offline). Typical pattern: seed `ChaCha20Rng` from HW RNG
 /// at startup, pass the `ChaCha20Rng` here.
 ///
-/// Cost: ~12% over [`x25519`] (288 vs 255 ladder iterations).
+/// Cost: ~2× [`x25519`] (544 vs 255 ladder iterations).
 #[inline(never)]
 pub fn x25519_blinded<T, R>(rng: &mut R, k: &[u8; 32], u_in: &[u8; 32]) -> [u8; 32]
 where
@@ -281,7 +286,7 @@ where
 
     let k_clamped = zeroize::Zeroizing::new(clamp(*k));
     let r = rng.next_u32();
-    let k_prime = zeroize::Zeroizing::new(compute_blinded_scalar(&k_clamped, r));
+    let k_prime = compute_blinded_scalar(&k_clamped, r);
 
     let mut u_bytes = *u_in;
     u_bytes[31] &= 0x7f;

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -34,10 +34,28 @@ pub const BASE_U_BYTES: [u8; 32] = [
     9, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 ];
 
+/// Full curve group order `8·ℓ`, used as the scalar-blinding modulus.
+///
+/// `ℓ` alone would not work: `ℓ mod 8 = 5`, so `r·ℓ` is not a multiple
+/// of 8 in general, which would break the RFC 7748 clamp invariant
+/// (clamped scalars must be multiples of 8 to clear cofactor torsion).
+/// `8·ℓ` is always a multiple of 8 and annihilates any point on the
+/// curve. Twist points are not annihilated — blinded results may
+/// diverge from unblinded for twist u-coords.
+pub const GROUP_ORDER_BYTES: [u8; 32] = [
+    0x68, 0x9f, 0xae, 0xe7, 0xd2, 0x18, 0x93, 0xc0, 0xb2, 0xe6, 0xbc, 0x17, 0xf5, 0xce, 0xf7, 0xa6,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x80,
+];
+
 /// Backends wider than this are rejected at runtime. 64 bytes covers all
 /// currently registered `FixedUInt` impls (u32×16, u64×8, u64×4, u8×32) and
 /// bounds the scratch buffers below.
 const MAX_T_BYTES: usize = 64;
+
+/// `k + r·(8·ℓ)` fits in 36 bytes for a 32-bit blinder `r`.
+const BLINDED_SCALAR_BYTES: usize = 36;
+
+const BLINDED_BIT_COUNT: usize = BLINDED_SCALAR_BYTES * 8;
 
 /// Apply the RFC 7748 scalar clamp: clear the bottom three bits of byte 0,
 /// clear the top bit of byte 31, and set bit 254.
@@ -46,6 +64,41 @@ pub const fn clamp(mut k: [u8; 32]) -> [u8; 32] {
     k[31] &= 127;
     k[31] |= 64;
     k
+}
+
+/// Compute `k' = k + r·(8·ℓ)` little-endian. Schoolbook in
+/// `u8`/`u16`/`u64` to avoid dragging in a wider `FixedUInt`.
+fn compute_blinded_scalar(k_clamped: &[u8; 32], r: u32) -> [u8; BLINDED_SCALAR_BYTES] {
+    let mut out = [0u8; BLINDED_SCALAR_BYTES];
+    let r = r as u64;
+
+    let mut carry: u64 = 0;
+    for i in 0..32 {
+        let prod = r * (GROUP_ORDER_BYTES[i] as u64) + carry;
+        out[i] = prod as u8;
+        carry = prod >> 8;
+    }
+    for byte in out.iter_mut().skip(32) {
+        carry += *byte as u64;
+        *byte = carry as u8;
+        carry >>= 8;
+    }
+    debug_assert_eq!(carry, 0);
+
+    let mut c: u16 = 0;
+    for (i, &kb) in k_clamped.iter().enumerate() {
+        let s = (out[i] as u16) + (kb as u16) + c;
+        out[i] = s as u8;
+        c = s >> 8;
+    }
+    for byte in out.iter_mut().skip(32) {
+        let s = (*byte as u16) + c;
+        *byte = s as u8;
+        c = s >> 8;
+    }
+    debug_assert_eq!(c, 0);
+
+    out
 }
 
 /// Compute `k * G` where `G` is the X25519 base point (u = 9).
@@ -152,54 +205,7 @@ where
     // Initial ladder state:
     //   (x2, z2) = (1, 0)   -- point at infinity
     //   (x3, z3) = (u, 1)   -- the input point
-    let mut x2 = field.one();
-    let mut z2 = field.zero();
-    let mut x3 = x1.clone();
-    let mut z3 = field.one();
-    let mut swap: u8 = 0;
-
-    // Process scalar bits 254..=0 (255 iterations). The conditional swap is
-    // performed with a branchless cswap so iteration control flow is
-    // identical regardless of the secret scalar. All field ops in the loop
-    // operate on secret-derived values via the CT primitives — and the type
-    // system enforces that: every variable here is a `ResidueCt`.
-    for t in (0..255).rev() {
-        let k_t = (k[t >> 3] >> (t & 7)) & 1;
-        swap ^= k_t;
-        let choice = Choice::from(swap);
-        ResidueCt::cswap(choice, &mut x2, &mut x3);
-        ResidueCt::cswap(choice, &mut z2, &mut z3);
-        swap = k_t;
-
-        // RFC 7748 §5 doubling-and-differential-addition step.
-        let a = field.add(&x2, &z2);
-        let aa = field.mul(&a, &a);
-        let b = field.sub(&x2, &z2);
-        let bb = field.mul(&b, &b);
-        let e = field.sub(&aa, &bb);
-        let c = field.add(&x3, &z3);
-        let d = field.sub(&x3, &z3);
-        let da = field.mul(&d, &a);
-        let cb = field.mul(&c, &b);
-
-        let da_plus_cb = field.add(&da, &cb);
-        x3 = field.mul(&da_plus_cb, &da_plus_cb);
-
-        let da_minus_cb = field.sub(&da, &cb);
-        let dmc_sq = field.mul(&da_minus_cb, &da_minus_cb);
-        z3 = field.mul(&x1, &dmc_sq);
-
-        x2 = field.mul(&aa, &bb);
-
-        let a24e = field.mul(&a24, &e);
-        let aa_plus_a24e = field.add(&aa, &a24e);
-        z2 = field.mul(&e, &aa_plus_a24e);
-    }
-
-    // Final conditional swap based on the last scalar bit — branchless.
-    let final_choice = Choice::from(swap);
-    ResidueCt::cswap(final_choice, &mut x2, &mut x3);
-    ResidueCt::cswap(final_choice, &mut z2, &mut z3);
+    let (x2, z2) = montgomery_ladder(&field, &x1, &a24, &*k, 255);
 
     // Return x2 * z2^{-1} mod p, encoded little-endian.
     // All CT — z2 is secret-derived.
@@ -221,4 +227,173 @@ where
     let mut out = [0u8; 32];
     out.copy_from_slice(&bytes[..32]);
     out
+}
+
+/// X25519 shared secret with scalar blinding: replaces `k` with
+/// `k' = k + r·(8·ℓ)` for a fresh 32-bit `r`. Output equals
+/// [`x25519`] for any curve-subgroup `u_in`; twist-point inputs may
+/// diverge — see [`GROUP_ORDER_BYTES`].
+///
+/// Defends against multi-trace DPA aggregation on a long-lived secret
+/// scalar. For single-trace correlation, combine with projective
+/// coordinate re-randomization (future).
+///
+/// `R: CryptoRng` is required — a predictable RNG is worse than no
+/// blinding (attacker recovers PRNG state from traces, removes the
+/// blinding offline). Typical pattern: seed `ChaCha20Rng` from HW RNG
+/// at startup, pass the `ChaCha20Rng` here.
+///
+/// Cost: ~12% over [`x25519`] (288 vs 255 ladder iterations).
+#[inline(never)]
+pub fn x25519_blinded<T, R>(rng: &mut R, k: &[u8; 32], u_in: &[u8; 32]) -> [u8; 32]
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+    R: rand_core::CryptoRng,
+{
+    let bits = modmath::type_bit_width::<T>();
+    assert!(
+        bits >= 256,
+        "x25519_blinded: backend T is {} bits, need at least 256",
+        bits
+    );
+    assert!(
+        bits <= MAX_T_BYTES * 8,
+        "x25519_blinded: backend T is {} bits, exceeds supported maximum of {}",
+        bits,
+        MAX_T_BYTES * 8
+    );
+
+    let p = T::from_bytes_le(&P_BYTES);
+    let field = Curve25519FieldCt::new(p).unwrap();
+
+    let k_clamped = zeroize::Zeroizing::new(clamp(*k));
+    let r = rng.next_u32();
+    let k_prime = zeroize::Zeroizing::new(compute_blinded_scalar(&k_clamped, r));
+
+    let mut u_bytes = *u_in;
+    u_bytes[31] &= 0x7f;
+    let u = T::from_bytes_le(&u_bytes);
+    let x1 = field.reduce(&u);
+    let a24 = field.reduce(&T::from_bytes_le(&A24_BYTES));
+
+    let (x2, z2) = montgomery_ladder(&field, &x1, &a24, &*k_prime, BLINDED_BIT_COUNT);
+
+    let z2_inv = field.inv(&z2);
+    let result_res = field.mul(&x2, &z2_inv);
+    let result = zeroize::Zeroizing::new(field.into_raw(&result_res));
+
+    let mut scratch = zeroize::Zeroizing::new([0u8; MAX_T_BYTES]);
+    let bytes = result.to_bytes_le(&mut *scratch);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes[..32]);
+    out
+}
+
+/// Compute `k * G` (where `G` is the X25519 base point) with scalar
+/// blinding. See [`x25519_blinded`] for the threat model and RNG
+/// requirement.
+pub fn x25519_base_blinded<T, R>(rng: &mut R, k: &[u8; 32]) -> [u8; 32]
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+    R: rand_core::CryptoRng,
+{
+    x25519_blinded::<T, R>(rng, k, &BASE_U_BYTES)
+}
+
+/// Shared ladder body. `x1` and `a24` are borrowed so the caller's
+/// `ZeroizeOnDrop` wipe still fires at its scope end — moving them in
+/// would leave the source bindings holding unwiped bytes.
+#[inline(never)]
+fn montgomery_ladder<'f, T>(
+    field: &'f Curve25519FieldCt<T>,
+    x1: &ResidueCt<'f, T>,
+    a24: &ResidueCt<'f, T>,
+    scalar: &[u8],
+    bit_count: usize,
+) -> (ResidueCt<'f, T>, ResidueCt<'f, T>)
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    let mut x2 = field.one();
+    let mut z2 = field.zero();
+    let mut x3 = x1.clone();
+    let mut z3 = field.one();
+    let mut swap: u8 = 0;
+
+    for t in (0..bit_count).rev() {
+        let k_t = (scalar[t >> 3] >> (t & 7)) & 1;
+        swap ^= k_t;
+        let choice = Choice::from(swap);
+        ResidueCt::cswap(choice, &mut x2, &mut x3);
+        ResidueCt::cswap(choice, &mut z2, &mut z3);
+        swap = k_t;
+
+        let a = field.add(&x2, &z2);
+        let aa = field.mul(&a, &a);
+        let b = field.sub(&x2, &z2);
+        let bb = field.mul(&b, &b);
+        let e = field.sub(&aa, &bb);
+        let c = field.add(&x3, &z3);
+        let d = field.sub(&x3, &z3);
+        let da = field.mul(&d, &a);
+        let cb = field.mul(&c, &b);
+
+        let da_plus_cb = field.add(&da, &cb);
+        x3 = field.mul(&da_plus_cb, &da_plus_cb);
+
+        let da_minus_cb = field.sub(&da, &cb);
+        let dmc_sq = field.mul(&da_minus_cb, &da_minus_cb);
+        z3 = field.mul(x1, &dmc_sq);
+
+        x2 = field.mul(&aa, &bb);
+
+        let a24e = field.mul(a24, &e);
+        let aa_plus_a24e = field.add(&aa, &a24e);
+        z2 = field.mul(&e, &aa_plus_a24e);
+    }
+
+    let final_choice = Choice::from(swap);
+    ResidueCt::cswap(final_choice, &mut x2, &mut x3);
+    ResidueCt::cswap(final_choice, &mut z2, &mut z3);
+
+    (x2, z2)
 }

--- a/ed25519/tests/wycheproof_x25519_blinded.rs
+++ b/ed25519/tests/wycheproof_x25519_blinded.rs
@@ -1,0 +1,50 @@
+//! Wycheproof X25519 corpus run through the blinded path. With the
+//! universal `8·ℓ·ℓ'` blinder, blinded must match unblinded for every
+//! accepted u-coordinate — curve or twist.
+
+#![cfg(feature = "fixed-bigint")]
+
+use ed25519_heapless::{x25519, x25519_blinded};
+use fixed_bigint::{Ct, FixedUInt};
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::SeedableRng;
+
+type T = FixedUInt<u32, 16, Ct>;
+
+#[test]
+fn wycheproof_x25519_blinded_matches_unblinded() {
+    let set = wycheproof::xdh::TestSet::load(wycheproof::xdh::TestName::X25519)
+        .expect("wycheproof X25519 corpus failed to load");
+
+    let mut rng = ChaCha20Rng::seed_from_u64(0xb1_1d_ed_25519);
+    let mut ran = 0usize;
+    let mut failures = 0usize;
+
+    for group in &set.test_groups {
+        for tc in &group.tests {
+            let priv_bytes: [u8; 32] = match tc.private_key.as_ref().try_into() {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let pub_bytes: [u8; 32] = match tc.public_key.as_ref().try_into() {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+
+            let unblinded = x25519::<T>(&priv_bytes, &pub_bytes);
+            let blinded = x25519_blinded::<T, _>(&mut rng, &priv_bytes, &pub_bytes);
+
+            ran += 1;
+            if blinded != unblinded {
+                eprintln!(
+                    "tcId {} ({:?}) flags={:?}: blinded {:02x?} vs unblinded {:02x?}",
+                    tc.tc_id, tc.comment, tc.flags, blinded, unblinded
+                );
+                failures += 1;
+            }
+        }
+    }
+
+    eprintln!("wycheproof X25519 blinded: ran={ran} failed={failures}");
+    assert_eq!(failures, 0);
+}

--- a/ed25519/tests/x25519_blinding.rs
+++ b/ed25519/tests/x25519_blinding.rs
@@ -81,6 +81,34 @@ fn blinded_with_zero_blinder_matches_unblinded() {
 }
 
 #[test]
+fn blinded_with_max_blinder_matches_unblinded() {
+    // r = u32::MAX exercises full-carry propagation through the
+    // schoolbook multiply and the high end of the 544-bit ladder loop.
+    struct MaxRng;
+    impl rand_chacha::rand_core::RngCore for MaxRng {
+        fn next_u32(&mut self) -> u32 {
+            u32::MAX
+        }
+        fn next_u64(&mut self) -> u64 {
+            u64::MAX
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            dest.fill(0xff);
+        }
+    }
+    impl rand_chacha::rand_core::CryptoRng for MaxRng {}
+
+    let k = deterministic_bytes(0xaa, 0x55);
+    let peer_secret = deterministic_bytes(0xaa, 0xa5);
+    let u = x25519_base::<T>(&peer_secret);
+
+    let unblinded = x25519::<T>(&k, &u);
+    let blinded = x25519_blinded::<T, _>(&mut MaxRng, &k, &u);
+
+    assert_eq!(blinded, unblinded);
+}
+
+#[test]
 fn blinded_produces_varying_intermediate_with_different_rng() {
     let mut rng_a = ChaCha20Rng::seed_from_u64(1);
     let mut rng_b = ChaCha20Rng::seed_from_u64(2);

--- a/ed25519/tests/x25519_blinding.rs
+++ b/ed25519/tests/x25519_blinding.rs
@@ -1,0 +1,98 @@
+//! `x25519_blinded` must match `x25519` for any curve-subgroup `u`.
+//! A divergence here is a crypto break, not just a leak.
+
+#![cfg(feature = "fixed-bigint")]
+
+use ed25519_heapless::{x25519, x25519_base, x25519_base_blinded, x25519_blinded};
+use fixed_bigint::{Ct, FixedUInt};
+use rand_chacha::ChaCha20Rng;
+use rand_chacha::rand_core::SeedableRng;
+
+type T = FixedUInt<u32, 16, Ct>;
+
+const N_TRIALS: usize = 50;
+
+fn deterministic_bytes(seed: u64, salt: u8) -> [u8; 32] {
+    let mut out = [0u8; 32];
+    for (i, b) in out.iter_mut().enumerate() {
+        *b = ((seed.wrapping_mul(i as u64 + 1)) as u8) ^ salt ^ (i as u8);
+    }
+    out
+}
+
+#[test]
+fn blinded_matches_unblinded_x25519() {
+    // `u` must be a subgroup point for the `8·ℓ` blinding identity to
+    // hold. Random 32-byte bytes land on the twist ~half the time;
+    // derive `u` via `x25519_base` instead.
+    let mut rng = ChaCha20Rng::seed_from_u64(0xed_25519_b1_1d);
+
+    for trial in 0..N_TRIALS {
+        let k = deterministic_bytes(trial as u64, 0xa5);
+        let peer_secret = deterministic_bytes(trial as u64, 0x5a);
+        let u = x25519_base::<T>(&peer_secret);
+
+        let unblinded = x25519::<T>(&k, &u);
+        let blinded = x25519_blinded::<T, _>(&mut rng, &k, &u);
+
+        assert_eq!(blinded, unblinded, "trial {trial} diverged");
+    }
+}
+
+#[test]
+fn blinded_matches_unblinded_x25519_base() {
+    let mut rng = ChaCha20Rng::seed_from_u64(0xed_25519_ba_5e);
+
+    for trial in 0..N_TRIALS {
+        let k = deterministic_bytes(trial as u64, 0xc3);
+
+        let unblinded = x25519_base::<T>(&k);
+        let blinded = x25519_base_blinded::<T, _>(&mut rng, &k);
+
+        assert_eq!(blinded, unblinded, "trial {trial} diverged");
+    }
+}
+
+#[test]
+fn blinded_with_zero_blinder_matches_unblinded() {
+    // r = 0 → k' = k zero-extended; exercises the wider ladder loop's
+    // leading-zero iterations.
+    struct ZeroRng;
+    impl rand_chacha::rand_core::RngCore for ZeroRng {
+        fn next_u32(&mut self) -> u32 {
+            0
+        }
+        fn next_u64(&mut self) -> u64 {
+            0
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            dest.fill(0);
+        }
+    }
+    impl rand_chacha::rand_core::CryptoRng for ZeroRng {}
+
+    let k = deterministic_bytes(0x42, 0xff);
+    let u = deterministic_bytes(0x42, 0x01);
+
+    let unblinded = x25519::<T>(&k, &u);
+    let blinded = x25519_blinded::<T, _>(&mut ZeroRng, &k, &u);
+
+    assert_eq!(blinded, unblinded);
+}
+
+#[test]
+fn blinded_produces_varying_intermediate_with_different_rng() {
+    let mut rng_a = ChaCha20Rng::seed_from_u64(1);
+    let mut rng_b = ChaCha20Rng::seed_from_u64(2);
+
+    let k = deterministic_bytes(99, 0x77);
+    let peer_secret = deterministic_bytes(99, 0x88);
+    let u = x25519_base::<T>(&peer_secret);
+
+    let unblinded = x25519::<T>(&k, &u);
+    let from_a = x25519_blinded::<T, _>(&mut rng_a, &k, &u);
+    let from_b = x25519_blinded::<T, _>(&mut rng_b, &k, &u);
+
+    assert_eq!(from_a, unblinded);
+    assert_eq!(from_b, unblinded);
+}

--- a/ed25519/tests/x25519_blinding.rs
+++ b/ed25519/tests/x25519_blinding.rs
@@ -22,9 +22,6 @@ fn deterministic_bytes(seed: u64, salt: u8) -> [u8; 32] {
 
 #[test]
 fn blinded_matches_unblinded_x25519() {
-    // `u` must be a subgroup point for the `8·ℓ` blinding identity to
-    // hold. Random 32-byte bytes land on the twist ~half the time;
-    // derive `u` via `x25519_base` instead.
     let mut rng = ChaCha20Rng::seed_from_u64(0xed_25519_b1_1d);
 
     for trial in 0..N_TRIALS {


### PR DESCRIPTION
x25519_blinded / x25519_base_blinded compute the X25519 shared secret using a per-invocation blinded scalar k' = k + r·(8·ℓ), where r is a fresh 32-bit draw from a caller-supplied CryptoRng. The output equals plain x25519 for any curve-subgroup u-coordinate.

## Summary by Sourcery

Introduce scalar-blinded X25519 operations to harden long-lived secret scalars against side-channel attacks while refactoring the Montgomery ladder for reuse with variable-length scalars.

New Features:
- Add x25519_blinded and x25519_base_blinded APIs that compute X25519 shared secrets and public keys using per-call scalar blinding driven by a caller-supplied CryptoRng.
- Expose GROUP_ORDER_BYTES constant representing the full curve group order 8·ℓ for use as the blinding modulus.

Enhancements:
- Refactor the Montgomery ladder core into a reusable montgomery_ladder function parameterized by scalar bit length to support both standard and blinded scalars.

Build:
- Add rand_core as a library dependency and rand_chacha as a dev-dependency for RNG-backed blinding and tests.

Tests:
- Add fixed-bigint-based tests verifying blinded X25519 operations match unblinded results for subgroup inputs, including edge cases such as zero blinder and different RNG seeds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added X25519 scalar blinding and new blinded key-exchange APIs; exports updated to expose blinded variants and related constants.

* **Chores**
  * Updated RNG-related dependencies (no-default-features to support no-std usage).

* **Tests**
  * Added deterministic and corpus-driven tests to validate blinded vs. unblinded X25519 behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->