### PR TITLE
Add projective coordinate re-randomization to x25519_blinded

### DIFF
--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -308,17 +308,18 @@ where
 
     // Projective re-randomization: scale the starting state by a random
     // nonzero λ ∈ F_p. Same geometric points, different bit patterns
-    // through the ladder — defeats single-trace correlation. A zero λ
-    // would degenerate (0, 0, 0, 0) into the ladder, so replace it
-    // with 1 in constant time (catches all-zero RNGs in tests; the
-    // CryptoRng case is vanishingly improbable).
+    // through the ladder — defeats single-trace correlation. Replace
+    // λ_t ∈ {0, p} with 1 in constant time, since both reduce to 0
+    // and a zero λ degenerates the initial state to (0, 0, 0, 0).
     let mut lambda_bytes = zeroize::Zeroizing::new([0u8; 32]);
     rng.fill_bytes(&mut *lambda_bytes);
     lambda_bytes[31] &= 0x7f;
-    let lambda_t = T::from_bytes_le(&*lambda_bytes);
-    let is_zero = subtle::ConstantTimeEq::ct_eq(&lambda_t, &T::zero());
-    let lambda_t = T::conditional_select(&lambda_t, &T::one(), is_zero);
-    let lambda = field.reduce(&lambda_t);
+    let p_t = T::from_bytes_le(&P_BYTES);
+    let mut lambda_t = zeroize::Zeroizing::new(T::from_bytes_le(&*lambda_bytes));
+    let is_zero = subtle::ConstantTimeEq::ct_eq(&*lambda_t, &T::zero());
+    let is_p = subtle::ConstantTimeEq::ct_eq(&*lambda_t, &p_t);
+    *lambda_t = T::conditional_select(&*lambda_t, &T::one(), is_zero | is_p);
+    let lambda = field.reduce(&*lambda_t);
     let lx1 = field.mul(&lambda, &x1);
 
     let (x2, z2) = montgomery_ladder(

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -207,10 +207,17 @@ where
     let x1 = field.reduce(&u);
     let a24 = field.reduce(&T::from_bytes_le(&A24_BYTES));
 
-    // Initial ladder state:
-    //   (x2, z2) = (1, 0)   -- point at infinity
-    //   (x3, z3) = (u, 1)   -- the input point
-    let (x2, z2) = montgomery_ladder(&field, &x1, &a24, &*k, 255);
+    let (x2, z2) = montgomery_ladder(
+        &field,
+        &x1,
+        &a24,
+        &*k,
+        255,
+        field.one(),
+        field.zero(),
+        x1.clone(),
+        field.one(),
+    );
 
     // Return x2 * z2^{-1} mod p, encoded little-endian.
     // All CT — z2 is secret-derived.
@@ -234,21 +241,26 @@ where
     out
 }
 
-/// X25519 shared secret with scalar blinding: replaces `k` with
-/// `k' = k + r·(8·ℓ·ℓ')` for a fresh 32-bit `r`. Output equals
-/// [`x25519`] for every accepted u-coordinate, curve or twist —
-/// see [`BLINDING_MODULUS_BYTES`].
+/// X25519 shared secret with full per-invocation blinding:
 ///
-/// Defends against multi-trace DPA aggregation on a long-lived secret
-/// scalar. For single-trace correlation, combine with projective
-/// coordinate re-randomization (future).
+/// * **Scalar blinding** — replaces `k` with `k' = k + r·(8·ℓ·ℓ')`
+///   for a fresh 32-bit `r`. Defeats multi-trace DPA aggregation
+///   against a long-lived secret scalar.
+/// * **Projective coordinate re-randomization** — scales the starting
+///   ladder state by a random nonzero `λ ∈ F_p`. Defeats single-trace
+///   correlation analysis between ladder iterations.
+///
+/// Output equals [`x25519`] for every accepted u-coordinate, curve or
+/// twist — see [`BLINDING_MODULUS_BYTES`].
 ///
 /// `R: CryptoRng` is required — a predictable RNG is worse than no
 /// blinding (attacker recovers PRNG state from traces, removes the
 /// blinding offline). Typical pattern: seed `ChaCha20Rng` from HW RNG
 /// at startup, pass the `ChaCha20Rng` here.
 ///
-/// Cost: ~2× [`x25519`] (544 vs 255 ladder iterations).
+/// Cost: ~2× [`x25519`] (544 vs 255 ladder iterations); the projective
+/// re-randomization adds one extra multiplication, negligible vs the
+/// ladder body.
 #[inline(never)]
 pub fn x25519_blinded<T, R>(rng: &mut R, k: &[u8; 32], u_in: &[u8; 32]) -> [u8; 32]
 where
@@ -294,7 +306,32 @@ where
     let x1 = field.reduce(&u);
     let a24 = field.reduce(&T::from_bytes_le(&A24_BYTES));
 
-    let (x2, z2) = montgomery_ladder(&field, &x1, &a24, &*k_prime, BLINDED_BIT_COUNT);
+    // Projective re-randomization: scale the starting state by a random
+    // nonzero λ ∈ F_p. Same geometric points, different bit patterns
+    // through the ladder — defeats single-trace correlation. A zero λ
+    // would degenerate (0, 0, 0, 0) into the ladder, so replace it
+    // with 1 in constant time (catches all-zero RNGs in tests; the
+    // CryptoRng case is vanishingly improbable).
+    let mut lambda_bytes = zeroize::Zeroizing::new([0u8; 32]);
+    rng.fill_bytes(&mut *lambda_bytes);
+    lambda_bytes[31] &= 0x7f;
+    let lambda_t = T::from_bytes_le(&*lambda_bytes);
+    let is_zero = subtle::ConstantTimeEq::ct_eq(&lambda_t, &T::zero());
+    let lambda_t = T::conditional_select(&lambda_t, &T::one(), is_zero);
+    let lambda = field.reduce(&lambda_t);
+    let lx1 = field.mul(&lambda, &x1);
+
+    let (x2, z2) = montgomery_ladder(
+        &field,
+        &x1,
+        &a24,
+        &*k_prime,
+        BLINDED_BIT_COUNT,
+        lambda.clone(),
+        field.zero(),
+        lx1,
+        lambda,
+    );
 
     let z2_inv = field.inv(&z2);
     let result_res = field.mul(&x2, &z2_inv);
@@ -331,16 +368,22 @@ where
     x25519_blinded::<T, R>(rng, k, &BASE_U_BYTES)
 }
 
-/// Shared ladder body. `x1` and `a24` are borrowed so the caller's
-/// `ZeroizeOnDrop` wipe still fires at its scope end — moving them in
-/// would leave the source bindings holding unwiped bytes.
+/// Shared ladder body. Caller supplies the initial projective state
+/// `(x2, z2, x3, z3)` so the blinded path can scale by a random λ.
+/// `x1` and `a24` are borrowed so the caller's `ZeroizeOnDrop` wipe
+/// still fires at its scope end.
 #[inline(never)]
+#[allow(clippy::too_many_arguments)]
 fn montgomery_ladder<'f, T>(
     field: &'f Curve25519FieldCt<T>,
     x1: &ResidueCt<'f, T>,
     a24: &ResidueCt<'f, T>,
     scalar: &[u8],
     bit_count: usize,
+    mut x2: ResidueCt<'f, T>,
+    mut z2: ResidueCt<'f, T>,
+    mut x3: ResidueCt<'f, T>,
+    mut z3: ResidueCt<'f, T>,
 ) -> (ResidueCt<'f, T>, ResidueCt<'f, T>)
 where
     T: UnsignedModularInt
@@ -358,10 +401,6 @@ where
         + core::ops::Sub<Output = T>,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
-    let mut x2 = field.one();
-    let mut z2 = field.zero();
-    let mut x3 = x1.clone();
-    let mut z3 = field.one();
     let mut swap: u8 = 0;
 
     for t in (0..bit_count).rev() {

--- a/ed25519/tests/x25519_blinding.rs
+++ b/ed25519/tests/x25519_blinding.rs
@@ -106,6 +106,41 @@ fn blinded_with_max_blinder_matches_unblinded() {
 }
 
 #[test]
+fn blinded_with_lambda_equal_to_p_matches_unblinded() {
+    // RNG feeds P_BYTES for the projective rerand λ bytes. After mask
+    // bytes[31] &= 0x7f, λ_t equals p exactly (p's high bit is 0
+    // already). field.reduce(p) == 0, so without the CT is_p check
+    // the ladder would degenerate to (0, 0, 0, 0) and diverge.
+    use ed25519_heapless::P_BYTES;
+    struct PRng {
+        scalar_done: bool,
+    }
+    impl rand_chacha::rand_core::RngCore for PRng {
+        fn next_u32(&mut self) -> u32 {
+            self.scalar_done = true;
+            0x1234_5678
+        }
+        fn next_u64(&mut self) -> u64 {
+            0
+        }
+        fn fill_bytes(&mut self, dest: &mut [u8]) {
+            assert!(self.scalar_done && dest.len() == 32);
+            dest.copy_from_slice(&P_BYTES);
+        }
+    }
+    impl rand_chacha::rand_core::CryptoRng for PRng {}
+
+    let k = deterministic_bytes(0x99, 0x33);
+    let peer_secret = deterministic_bytes(0x99, 0x66);
+    let u = x25519_base::<T>(&peer_secret);
+
+    let unblinded = x25519::<T>(&k, &u);
+    let blinded = x25519_blinded::<T, _>(&mut PRng { scalar_done: false }, &k, &u);
+
+    assert_eq!(blinded, unblinded);
+}
+
+#[test]
 fn blinded_produces_varying_intermediate_with_different_rng() {
     let mut rng_a = ChaCha20Rng::seed_from_u64(1);
     let mut rng_b = ChaCha20Rng::seed_from_u64(2);


### PR DESCRIPTION
x25519_blinded now layers projective re-randomization on top of the existing scalar blinding: at the start of the ladder, generate a random nonzero λ ∈ F_p and scale the starting projective state (x2, z2, x3, z3) by λ. Geometrically identical points, different bit patterns through the iteration — defeats single-trace correlation analysis between ladder steps, the threat model scalar blinding does not cover.

## Summary by Sourcery

Add per-invocation projective coordinate re-randomization to the X25519 blinded scalar multiplication while refactoring the Montgomery ladder to accept an explicit initial projective state.

New Features:
- Introduce projective coordinate re-randomization in x25519_blinded by scaling the initial ladder state with a random nonzero field element to harden against single-trace side-channel attacks.

Enhancements:
- Refactor the Montgomery ladder helper to take the initial projective coordinates as parameters, enabling reuse for both blinded and unblinded X25519 paths.
- Clarify documentation for x25519_blinded to describe both scalar blinding and projective re-randomization, including their threat models and performance impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced X25519 blinded operations with projective coordinate re-randomization.
  * Modified internal coordinate initialization to accept explicit parameters from caller.

* **Documentation**
  * Updated documentation for X25519 blinded operations to reflect added randomization step.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->