### PR TITLE
Bump signature 2.2 → 3.0, rand_core 0.9 → 0.10, version 0.1.0 → 0.2.0

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519_heapless"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 description = "Ed25519 signature verification and X25519 key exchange, generic over bigint backends"
 license = "GPL-3.0-only"
@@ -19,12 +19,12 @@ num-traits = {  version = "0.2" , default-features = false }
 zeroize = { version = "1.8", default-features = false }
 hmac-sha512 = { version = "1", default-features = false, features = ["opt_size"], optional = true }
 sha2 = { version = "0.10", default-features = false, features = ["force-soft-compact"], optional = true }
-signature = { version = "2.2", default-features = false }
-rand_core = { version = "0.9", default-features = false }
+signature = { version = "3.0", default-features = false }
+rand_core = { version = "0.10", default-features = false }
 
 [dev-dependencies]
 wycheproof = { version = "0.6", default-features = false, features = ["xdh", "eddsa"] }
-rand_chacha = { version = "0.9", default-features = false }
+rand_chacha = { version = "0.10", default-features = false }
 
 [features]
 default = ["std", "sha512-hmac-sha512"]

--- a/ed25519/tests/x25519_blinding.rs
+++ b/ed25519/tests/x25519_blinding.rs
@@ -55,18 +55,20 @@ fn blinded_with_zero_blinder_matches_unblinded() {
     // r = 0 → k' = k zero-extended; exercises the wider ladder loop's
     // leading-zero iterations.
     struct ZeroRng;
-    impl rand_chacha::rand_core::RngCore for ZeroRng {
-        fn next_u32(&mut self) -> u32 {
-            0
+    impl rand_chacha::rand_core::TryRng for ZeroRng {
+        type Error = core::convert::Infallible;
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(0)
         }
-        fn next_u64(&mut self) -> u64 {
-            0
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            Ok(0)
         }
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
             dest.fill(0);
+            Ok(())
         }
     }
-    impl rand_chacha::rand_core::CryptoRng for ZeroRng {}
+    impl rand_chacha::rand_core::TryCryptoRng for ZeroRng {}
 
     let k = deterministic_bytes(0x42, 0xff);
     let u = deterministic_bytes(0x42, 0x01);
@@ -82,18 +84,20 @@ fn blinded_with_max_blinder_matches_unblinded() {
     // r = u32::MAX exercises full-carry propagation through the
     // schoolbook multiply and the high end of the 544-bit ladder loop.
     struct MaxRng;
-    impl rand_chacha::rand_core::RngCore for MaxRng {
-        fn next_u32(&mut self) -> u32 {
-            u32::MAX
+    impl rand_chacha::rand_core::TryRng for MaxRng {
+        type Error = core::convert::Infallible;
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Ok(u32::MAX)
         }
-        fn next_u64(&mut self) -> u64 {
-            u64::MAX
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            Ok(u64::MAX)
         }
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
             dest.fill(0xff);
+            Ok(())
         }
     }
-    impl rand_chacha::rand_core::CryptoRng for MaxRng {}
+    impl rand_chacha::rand_core::TryCryptoRng for MaxRng {}
 
     let k = deterministic_bytes(0xaa, 0x55);
     let peer_secret = deterministic_bytes(0xaa, 0xa5);
@@ -115,20 +119,22 @@ fn blinded_with_lambda_equal_to_p_matches_unblinded() {
     struct PRng {
         scalar_done: bool,
     }
-    impl rand_chacha::rand_core::RngCore for PRng {
-        fn next_u32(&mut self) -> u32 {
+    impl rand_chacha::rand_core::TryRng for PRng {
+        type Error = core::convert::Infallible;
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
             self.scalar_done = true;
-            0x1234_5678
+            Ok(0x1234_5678)
         }
-        fn next_u64(&mut self) -> u64 {
-            0
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            Ok(0)
         }
-        fn fill_bytes(&mut self, dest: &mut [u8]) {
+        fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), Self::Error> {
             assert!(self.scalar_done && dest.len() == 32);
             dest.copy_from_slice(&P_BYTES);
+            Ok(())
         }
     }
-    impl rand_chacha::rand_core::CryptoRng for PRng {}
+    impl rand_chacha::rand_core::TryCryptoRng for PRng {}
 
     let k = deterministic_bytes(0x99, 0x33);
     let peer_secret = deterministic_bytes(0x99, 0x66);


### PR DESCRIPTION
signature 3.0 keeps the Verifier<S> trait signature unchanged, so the impl in lib.rs:239 needs zero code changes. The transitive dep churn:

- signature: 2.2 → 3.0 (no API change for us; alloc/std features realigned).
- rand_core: 0.9 → 0.10 (signature 3.0 pulls 0.10, keep us aligned to avoid two-version compile).
- rand_chacha: 0.9 → 0.10 (dev-dep, matches rand_core).

rand_core 0.10 reorganized the trait hierarchy:
  RngCore → Rng (subtrait of TryRng<Error = Infallible>) CryptoRng → CryptoRng (subtrait of Rng + TryCryptoRng)
  + blanket: impl<R: TryRng<Error=Infallible>> Rng for R
  + blanket: impl<R: TryCryptoRng<Error=Infallible>> CryptoRng for R

The deprecated RngCore stub still exists, but consumers should write the new path. Our public API uses `R: rand_core::CryptoRng` as a bound on x25519_blinded — that name and contract are unchanged, just the supertrait set shifted.

Version 0.1.0 → 0.2.0 because the signature major bump is observable in our public Verifier impl signature: downstream consumers who follow our `signature` version transitively will need to bump theirs too. No source-level break in our own API.

## Summary by Sourcery

Bump cryptography-related dependencies to their latest major versions and adjust RNG-based tests to the new rand_core trait hierarchy.

Enhancements:
- Update signature to 3.0 and align rand_core and rand_chacha to 0.10 across the crate.
- Adapt custom RNG stubs in x25519 blinding tests to use the new TryRng/TryCryptoRng traits.

Chores:
- Bump crate version from 0.1.0 to 0.2.0 to reflect the dependency major updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Bumped crate version to 0.2.0
  * Upgraded signature dependency to 3.0, rand_core to 0.10, and rand_chacha to 0.10

* **Tests**
  * Updated x25519 blinding validation tests to align with updated cryptographic trait implementations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->