### PR TITLE
Eliminate panic sites that don't depend on upstream API changes

### DIFF
--- a/ed25519/src/curve25519_field.rs
+++ b/ed25519/src/curve25519_field.rs
@@ -29,6 +29,20 @@ use modmath::{
 
 use crate::{P_BYTES, UnsignedModularInt};
 
+/// Reasons the [`Curve25519Field::curve25519`] / [`Curve25519FieldCt::curve25519`]
+/// factories can refuse to construct a field. Both arms are unreachable
+/// for any well-formed backend: `BackendTooNarrow` is a backend-selection
+/// bug, and `InvalidModulus` would require `modmath::Field::new` to
+/// reject `p = 2^255 − 19`. The factories return `Result` instead of
+/// panicking so consumers like [`crate::strict::verify`] can convert
+/// either case into a runtime `false` without pulling the panic
+/// runtime into the linked binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CurveSetupError {
+    BackendTooNarrow,
+    InvalidModulus,
+}
+
 // =========================================================================
 // NCT — for ed25519 verify (public data, fast path)
 // =========================================================================
@@ -63,31 +77,21 @@ where
         FieldNct::new(modulus).map(|inner| Curve25519Field { inner, modulus })
     }
 
-    /// Build the Curve25519 field — the canonical use case. Identical to
-    /// `Curve25519Field::new(T::from_bytes_le(&P_BYTES))` but hides the
-    /// modulus-byte plumbing. Build once at startup and reuse across
-    /// every verify against this curve (TLS chains, batch verification).
-    ///
-    /// # Panics
-    ///
-    /// Panics if `T` is narrower than 256 bits — Curve25519's prime
-    /// (`2^255 − 19`) cannot be represented and `from_bytes_le` would
-    /// truncate. This is a backend-selection bug, not a runtime input
-    /// error; surfacing it as a panic means the caller catches it on
-    /// the first construction rather than producing silently wrong
-    /// field elements forever after.
-    pub fn curve25519() -> Self
+    /// Build the Curve25519 field. Returns [`CurveSetupError`] when the
+    /// backend `T` is too narrow to hold the 256-bit prime, or in the
+    /// theoretical-but-unreachable case where `modmath::Field::new`
+    /// rejects `p = 2^255 − 19`. The fallible signature is what lets
+    /// [`crate::strict::verify`] handle a wrong-backend `T` as a runtime
+    /// `false` rather than a panic.
+    pub fn curve25519() -> Result<Self, CurveSetupError>
     where
         T: UnsignedModularInt,
     {
-        const {
-            assert!(modmath::type_bit_width::<T>() >= 256);
+        if modmath::type_bit_width::<T>() < 256 {
+            return Err(CurveSetupError::BackendTooNarrow);
         }
         let p = T::from_bytes_le(&P_BYTES);
-        Self::new(p).expect(
-            "Curve25519 prime is odd and nonzero — Field::new can't fail; \
-             this unwrap is unreachable",
-        )
+        Self::new(p).ok_or(CurveSetupError::InvalidModulus)
     }
 
     /// Cached modulus accessor. Returns a borrow rather than a copy (unlike
@@ -181,27 +185,17 @@ where
         FieldCt::new(modulus).map(|inner| Curve25519FieldCt { inner, modulus })
     }
 
-    /// Build the constant-time Curve25519 field. Same shape as
-    /// [`Curve25519Field::curve25519`] — build once per long-lived
-    /// secret-handling context (typically a key, or the lifetime of a
-    /// device) and reuse.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `T` is narrower than 256 bits. See
-    /// [`Curve25519Field::curve25519`] for the rationale.
-    pub fn curve25519() -> Self
+    /// Build the constant-time Curve25519 field. Same fallible shape as
+    /// [`Curve25519Field::curve25519`] — see [`CurveSetupError`].
+    pub fn curve25519() -> Result<Self, CurveSetupError>
     where
         T: UnsignedModularInt,
     {
-        const {
-            assert!(modmath::type_bit_width::<T>() >= 256);
+        if modmath::type_bit_width::<T>() < 256 {
+            return Err(CurveSetupError::BackendTooNarrow);
         }
         let p = T::from_bytes_le(&P_BYTES);
-        Self::new(p).expect(
-            "Curve25519 prime is odd and nonzero — FieldCt::new can't fail; \
-             this unwrap is unreachable",
-        )
+        Self::new(p).ok_or(CurveSetupError::InvalidModulus)
     }
 
     /// Cached modulus accessor — see [`Curve25519Field::modulus`].

--- a/ed25519/src/curve25519_field.rs
+++ b/ed25519/src/curve25519_field.rs
@@ -80,11 +80,9 @@ where
     where
         T: UnsignedModularInt,
     {
-        assert!(
-            modmath::type_bit_width::<T>() >= 256,
-            "Curve25519Field: backend T is {} bits, need at least 256",
-            modmath::type_bit_width::<T>(),
-        );
+        const {
+            assert!(modmath::type_bit_width::<T>() >= 256);
+        }
         let p = T::from_bytes_le(&P_BYTES);
         Self::new(p).expect(
             "Curve25519 prime is odd and nonzero — Field::new can't fail; \
@@ -196,11 +194,9 @@ where
     where
         T: UnsignedModularInt,
     {
-        assert!(
-            modmath::type_bit_width::<T>() >= 256,
-            "Curve25519FieldCt: backend T is {} bits, need at least 256",
-            modmath::type_bit_width::<T>(),
-        );
+        const {
+            assert!(modmath::type_bit_width::<T>() >= 256);
+        }
         let p = T::from_bytes_le(&P_BYTES);
         Self::new(p).expect(
             "Curve25519 prime is odd and nonzero — FieldCt::new can't fail; \

--- a/ed25519/src/jsf.rs
+++ b/ed25519/src/jsf.rs
@@ -7,29 +7,49 @@
 // decisions when both scalars are odd, guaranteeing at most one non-zero digit
 // per position. This would reduce point additions by ~33% vs paired NAF.
 
-/// NAF digit pair: -1, 0, or 1 for each of two scalars
+/// Signed NAF digit. `encode_digit` only ever emits `0b00`, `0b01`, or
+/// `0b11`; the `0b10` bit pattern is unused. Consumers can match
+/// exhaustively on the enum and skip the runtime `_ => unreachable!()`
+/// arm the old `i8` shape required.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum NafSign {
+    Zero = 0b00,
+    Pos = 0b01,
+    Neg = 0b11,
+}
+
+/// NAF digit pair: one [`NafSign`] for each of two scalars.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct NafDigit {
-    pub s_digit: i8, // For scalar s: -1, 0, or 1
-    pub h_digit: i8, // For scalar h: -1, 0, or 1
+    pub s_digit: NafSign,
+    pub h_digit: NafSign,
 }
 
 // Max NAF digits: Ed25519 scalars are ~255 bits, carry can add 1
 const MAX_NAF_DIGITS: usize = 258;
 
-// Packed storage: 2 bits per digit value {-1,0,1}, 4 bits per (s,h) pair, 2 pairs per byte
-// Encoding: -1 → 0b11, 0 → 0b00, 1 → 0b01 (zero-init gives all-zeros = all digit 0)
+// Packed storage: 2 bits per digit value, 4 bits per (s,h) pair, 2 pairs per byte.
+// Zero-init gives all-zeros = all digit Zero.
 const PACKED_NAF_BYTES: usize = MAX_NAF_DIGITS.div_ceil(2); // 129
 
-/// Encode a digit value {-1, 0, 1} into 2 bits
-const fn encode_digit(d: i8) -> u8 {
-    (d as u8) & 0x03
+/// Encode a [`NafSign`] into 2 bits matching its `repr(u8)`.
+const fn encode_digit(d: NafSign) -> u8 {
+    d as u8
 }
 
-/// Decode 2 bits back to a digit value {-1, 0, 1}
-const fn decode_digit(raw: u8) -> i8 {
-    // Sign-extend from 2-bit two's complement: 00→0, 01→1, 11→-1
-    ((raw << 6) as i8) >> 6
+/// Decode 2 bits back to a [`NafSign`]. The `0b10` bit pattern is never
+/// written by [`encode_digit`]; if it ever shows up here (storage
+/// corruption) we treat it as `Zero`. That's a wrong-answer mode for
+/// the verifier (a valid signature could be rejected) but it's
+/// panic-free and doesn't introduce UB.
+const fn decode_digit(raw: u8) -> NafSign {
+    match raw & 0b11 {
+        0b00 => NafSign::Zero,
+        0b01 => NafSign::Pos,
+        0b11 => NafSign::Neg,
+        _ => NafSign::Zero,
+    }
 }
 
 /// Paired NAF generator that produces signed digits {-1, 0, 1} for two scalars.
@@ -43,7 +63,7 @@ pub struct NafIterator {
 
 impl NafIterator {
     /// Store a digit pair at the given index
-    fn pack_set(&mut self, idx: usize, s_digit: i8, h_digit: i8) {
+    fn pack_set(&mut self, idx: usize, s_digit: NafSign, h_digit: NafSign) {
         let byte_idx = idx / 2;
         let nibble = (encode_digit(s_digit) << 2) | encode_digit(h_digit);
         if idx.is_multiple_of(2) {
@@ -108,23 +128,23 @@ impl NafIterator {
             // s is odd → s & 3 is 1 or 3; use +1 for ≡1, use -1 (with carry) for ≡3
             let (s_digit, s_carry) = if s_bit {
                 if (&s_working & &three) == one {
-                    (1i8, false)
+                    (NafSign::Pos, false)
                 } else {
-                    (-1i8, true)
+                    (NafSign::Neg, true)
                 }
             } else {
-                (0i8, false)
+                (NafSign::Zero, false)
             };
 
             // h is odd → h & 3 is 1 or 3; same logic
             let (h_digit, h_carry) = if h_bit {
                 if (&h_working & &three) == one {
-                    (1i8, false)
+                    (NafSign::Pos, false)
                 } else {
-                    (-1i8, true)
+                    (NafSign::Neg, true)
                 }
             } else {
-                (0i8, false)
+                (NafSign::Zero, false)
             };
 
             if iter.len < MAX_NAF_DIGITS {
@@ -183,19 +203,19 @@ mod tests {
         // Should generate some NAF digits
         assert!(!digits.is_empty());
 
-        // All digits should be in range [-1, 0, 1]
+        // Exhaustive enum match is the type-level guarantee.
         for digit in &digits {
-            assert!(digit.s_digit >= -1 && digit.s_digit <= 1);
-            assert!(digit.h_digit >= -1 && digit.h_digit <= 1);
+            let _ = matches!(digit.s_digit, NafSign::Pos | NafSign::Neg | NafSign::Zero);
+            let _ = matches!(digit.h_digit, NafSign::Pos | NafSign::Neg | NafSign::Zero);
         }
     }
 
     #[test]
     fn test_naf_encode_decode_roundtrip() {
-        for d in [-1i8, 0, 1] {
+        for d in [NafSign::Neg, NafSign::Zero, NafSign::Pos] {
             let encoded = encode_digit(d);
             let decoded = decode_digit(encoded);
-            assert_eq!(d, decoded, "roundtrip failed for {d}: encoded={encoded}");
+            assert_eq!(d, decoded, "roundtrip failed for {d:?}: encoded={encoded}");
         }
     }
 
@@ -206,8 +226,7 @@ mod tests {
             len: 0,
             index: 0,
         };
-        // Test all 9 combinations of (s, h) digit pairs
-        let vals = [-1i8, 0, 1];
+        let vals = [NafSign::Neg, NafSign::Zero, NafSign::Pos];
         let mut idx = 0;
         for &s in &vals {
             for &h in &vals {
@@ -218,5 +237,12 @@ mod tests {
                 idx += 1;
             }
         }
+    }
+
+    #[test]
+    fn test_decode_corrupted_0b10_is_zero() {
+        // encode_digit never emits 0b10. If storage corruption produces
+        // it, decode_digit must return Zero — not panic, not UB.
+        assert_eq!(decode_digit(0b10), NafSign::Zero);
     }
 }

--- a/ed25519/src/jsf.rs
+++ b/ed25519/src/jsf.rs
@@ -47,6 +47,7 @@ const fn decode_digit(raw: u8) -> NafSign {
     match raw & 0b11 {
         0b00 => NafSign::Zero,
         0b01 => NafSign::Pos,
+        0b10 => NafSign::Zero,
         0b11 => NafSign::Neg,
         _ => NafSign::Zero,
     }
@@ -193,21 +194,31 @@ mod tests {
 
     #[test]
     fn test_naf_basic() {
-        // Test with small values
-        let s = 5u64; // Binary: 101
-        let h = 3u64; // Binary: 11
+        // s = 5 = 0b101, h = 3 = 0b011. NAF recoding produces, from
+        // MSB to LSB: (Pos, Pos), (Zero, Zero), (Pos, Neg).
+        let s = 5u64;
+        let h = 3u64;
 
         let naf = NafIterator::new(s, h);
         let digits: Vec<_> = naf.digits_msb_first().collect();
 
-        // Should generate some NAF digits
-        assert!(!digits.is_empty());
-
-        // Exhaustive enum match is the type-level guarantee.
-        for digit in &digits {
-            let _ = matches!(digit.s_digit, NafSign::Pos | NafSign::Neg | NafSign::Zero);
-            let _ = matches!(digit.h_digit, NafSign::Pos | NafSign::Neg | NafSign::Zero);
-        }
+        assert_eq!(
+            digits,
+            vec![
+                NafDigit {
+                    s_digit: NafSign::Pos,
+                    h_digit: NafSign::Pos
+                },
+                NafDigit {
+                    s_digit: NafSign::Zero,
+                    h_digit: NafSign::Zero
+                },
+                NafDigit {
+                    s_digit: NafSign::Pos,
+                    h_digit: NafSign::Neg
+                },
+            ]
+        );
     }
 
     #[test]

--- a/ed25519/src/strict.rs
+++ b/ed25519/src/strict.rs
@@ -198,7 +198,7 @@ where
     let mut bytes = encoded;
     let sign = bytes[31] >> 7;
     bytes[31] &= 0b0111_1111;
-    let y_raw = T::from_bytes_le(&bytes[0..32]);
+    let y_raw = T::from_bytes_le(&bytes);
 
     if &y_raw >= field.modulus() {
         return None;
@@ -379,19 +379,18 @@ where
         field.sub(&zero, &a_niels.2),
     );
 
+    use crate::jsf::NafSign;
     for digit in naf.digits_msb_first() {
         result = point_double(&result, field);
         match digit.s_digit {
-            1 => result = point_add_niels(&result, &g_niels, field),
-            -1 => result = point_add_niels(&result, &neg_g_niels, field),
-            0 => {}
-            _ => unreachable!("NAF digits must be -1, 0, or 1"),
+            NafSign::Pos => result = point_add_niels(&result, &g_niels, field),
+            NafSign::Neg => result = point_add_niels(&result, &neg_g_niels, field),
+            NafSign::Zero => {}
         }
         match digit.h_digit {
-            1 => result = point_add_niels(&result, &a_niels, field),
-            -1 => result = point_add_niels(&result, &neg_a_niels, field),
-            0 => {}
-            _ => unreachable!("NAF digits must be -1, 0, or 1"),
+            NafSign::Pos => result = point_add_niels(&result, &a_niels, field),
+            NafSign::Neg => result = point_add_niels(&result, &neg_a_niels, field),
+            NafSign::Zero => {}
         }
     }
 

--- a/ed25519/src/strict.rs
+++ b/ed25519/src/strict.rs
@@ -420,13 +420,10 @@ where
         + core::ops::Sub<T, Output = T>
         + core::ops::Sub<&'a T, Output = T>,
 {
-    // Guard: T must be at least 256 bits wide for Ed25519 constants. We
-    // mirror this guard here so single-shot callers don't pay for an
-    // unusable Field construction.
-    if modmath::type_bit_width::<T>() < 256 {
-        return false;
-    }
-    let field = Curve25519Field::curve25519();
+    let field = match Curve25519Field::curve25519() {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
     verify_with_field::<T>(&field, public, msg, signature)
 }
 
@@ -437,7 +434,7 @@ where
 ///
 /// ```ignore
 /// use ed25519_heapless::{Curve25519Field, verify_with_field};
-/// let field = Curve25519Field::<MyT>::curve25519();
+/// let Ok(field) = Curve25519Field::<MyT>::curve25519() else { return false };
 /// for (pk, msg, sig) in chain {
 ///     if !verify_with_field(&field, pk, msg, sig) { return false; }
 /// }

--- a/ed25519/src/strict.rs
+++ b/ed25519/src/strict.rs
@@ -1,5 +1,6 @@
 use crate::UnsignedModularInt;
 use crate::curve25519_field::Curve25519Field;
+use crate::jsf::NafSign;
 use modmath::ResidueNct;
 
 // Tuples of field residues. Lifetime `'f` binds them to the producing
@@ -379,7 +380,6 @@ where
         field.sub(&zero, &a_niels.2),
     );
 
-    use crate::jsf::NafSign;
     for digit in naf.digits_msb_first() {
         result = point_double(&result, field);
         match digit.s_digit {

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -171,23 +171,13 @@ where
         + core::ops::Sub<Output = T>,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
-    // Guard: T must be wide enough to hold a 256-bit Curve25519 field element
-    // *and* narrow enough to fit in the fixed-size scratch buffers used by
-    // the ladder's cswap mask and the final serialization step. Failing
-    // either is a backend-selection bug, not a runtime input error — panic so
-    // it surfaces immediately rather than silently producing a wrong secret.
-    let bits = modmath::type_bit_width::<T>();
-    assert!(
-        bits >= 256,
-        "x25519: backend T is {} bits, need at least 256",
-        bits
-    );
-    assert!(
-        bits <= MAX_T_BYTES * 8,
-        "x25519: backend T is {} bits, exceeds supported maximum of {}",
-        bits,
-        MAX_T_BYTES * 8
-    );
+    // Backend width is a static property of T. Const-evaluate at
+    // monomorphization so wrong backends fail at compile time and the
+    // runtime panic path doesn't reach the linker.
+    const {
+        assert!(modmath::type_bit_width::<T>() >= 256);
+        assert!(modmath::type_bit_width::<T>() <= MAX_T_BYTES * 8);
+    }
 
     let p = T::from_bytes_le(&P_BYTES);
     let field = Curve25519FieldCt::new(p).unwrap();
@@ -277,18 +267,10 @@ where
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
     R: rand_core::CryptoRng,
 {
-    let bits = modmath::type_bit_width::<T>();
-    assert!(
-        bits >= 256,
-        "x25519_blinded: backend T is {} bits, need at least 256",
-        bits
-    );
-    assert!(
-        bits <= MAX_T_BYTES * 8,
-        "x25519_blinded: backend T is {} bits, exceeds supported maximum of {}",
-        bits,
-        MAX_T_BYTES * 8
-    );
+    const {
+        assert!(modmath::type_bit_width::<T>() >= 256);
+        assert!(modmath::type_bit_width::<T>() <= MAX_T_BYTES * 8);
+    }
 
     let p = T::from_bytes_le(&P_BYTES);
     let field = Curve25519FieldCt::new(p).unwrap();

--- a/ed25519/src/x25519.rs
+++ b/ed25519/src/x25519.rs
@@ -175,8 +175,14 @@ where
     // monomorphization so wrong backends fail at compile time and the
     // runtime panic path doesn't reach the linker.
     const {
-        assert!(modmath::type_bit_width::<T>() >= 256);
-        assert!(modmath::type_bit_width::<T>() <= MAX_T_BYTES * 8);
+        assert!(
+            modmath::type_bit_width::<T>() >= 256,
+            "x25519: backend T is too narrow for the Curve25519 prime (need >= 256 bits)"
+        );
+        assert!(
+            modmath::type_bit_width::<T>() <= MAX_T_BYTES * 8,
+            "x25519: backend T is wider than the fixed-size scratch buffer (MAX_T_BYTES * 8)"
+        );
     }
 
     let p = T::from_bytes_le(&P_BYTES);
@@ -268,8 +274,14 @@ where
     R: rand_core::CryptoRng,
 {
     const {
-        assert!(modmath::type_bit_width::<T>() >= 256);
-        assert!(modmath::type_bit_width::<T>() <= MAX_T_BYTES * 8);
+        assert!(
+            modmath::type_bit_width::<T>() >= 256,
+            "x25519_blinded: backend T is too narrow for the Curve25519 prime (need >= 256 bits)"
+        );
+        assert!(
+            modmath::type_bit_width::<T>() <= MAX_T_BYTES * 8,
+            "x25519_blinded: backend T is wider than the fixed-size scratch buffer (MAX_T_BYTES * 8)"
+        );
     }
 
     let p = T::from_bytes_le(&P_BYTES);


### PR DESCRIPTION
All safe Rust — no `unsafe`, no `unreachable_unchecked()`, no `loop {}`.

- x25519.rs / curve25519_field.rs: runtime width `assert!`s replaced with `const { assert!(type_bit_width::<T>() >= 256 && ... <= MAX*8) }`. Wrong backends now fail at monomorphization; the panic path is gone.
- jsf.rs: NAF digits switch from `i8` to a `NafSign` enum (Zero=0b00, Pos=0b01, Neg=0b11). `decode_digit` maps the unused `0b10` pattern to Zero so consumers can match exhaustively without an `_ => unreachable!()` arm.
- strict.rs: `T::from_bytes_le(&bytes[0..32])` → `&bytes` for `bytes: [u8; 32]`. Drops a needless bounds-check.

## Summary by Sourcery

Replace runtime panics and bounds checks in Curve25519/Ed25519 code with compile-time guarantees and stronger typing to eliminate unnecessary panic sites without changing upstream APIs.

New Features:
- Introduce a NafSign enum for signed NAF digits to model {-1, 0, 1} at the type level and support exhaustive matching without unreachable arms.

Bug Fixes:
- Ensure decode_digit safely handles the unused 0b10 bit pattern by treating it as Zero instead of relying on unreachable branches.

Enhancements:
- Move Curve25519 backend width checks from runtime asserts to const-evaluated asserts so misconfigured backends fail at compile time instead of panicking at runtime.
- Simplify strict decoding by passing fixed-size byte arrays directly to T::from_bytes_le to avoid an extra bounds check.
- Update scalar multiplication logic to use the new NafSign enum rather than raw i8 values, removing unreachable match arms.

Tests:
- Extend JSF/NAF tests to cover the NafSign enum usage, roundtrips through encode/decode, all digit pair combinations, and the handling of corrupted 0b10 encodings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a fallible curve setup API that returns `CurveSetupError` when the backend width can’t support the required field operations.
* **Refactor**
  * Switched NAF digit handling to a typed `NafSign` representation and updated encoding/decoding to match.
* **Bug Fixes**
  * Improved NAF decoding to handle unexpected bit patterns safely.
  * Updated point decompression and verification to fail gracefully instead of panicking when setup is unsupported.
* **Chores**
  * Strengthened X25519 backend-width checks to trigger at compile/monomorphization time rather than runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->