### PR TITLE
Ed25519 sign — SigningKey + Signer trait (constant-time)

### DIFF
--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -146,10 +146,8 @@ impl<P: fixed_bigint::Personality> UnsignedModularInt for fixed_bigint::FixedUIn
 pub trait SignBackend:
     UnsignedModularInt
     + Copy
-    + PartialEq
     + modmath::WideMul
     + modmath::CiosMontMulCt
-    + modmath::Parity
     + num_traits::WrappingMul
     + num_traits::WrappingAdd
     + num_traits::WrappingSub
@@ -164,10 +162,8 @@ pub trait SignBackend:
 impl<T> SignBackend for T where
     T: UnsignedModularInt
         + Copy
-        + PartialEq
         + modmath::WideMul
         + modmath::CiosMontMulCt
-        + modmath::Parity
         + num_traits::WrappingMul
         + num_traits::WrappingAdd
         + num_traits::WrappingSub

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -287,7 +287,8 @@ where
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
         + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + zeroize::DefaultIsZeroes,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<[u8; 64], signature::Error> {

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -46,9 +46,16 @@ pub(crate) mod curve25519_field;
 #[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
 pub(crate) mod jsf;
 #[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+pub(crate) mod scalar_field;
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+pub(crate) mod signing_key;
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
 pub(crate) mod strict;
 #[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
 pub(crate) mod strict_sign;
+
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+pub use signing_key::{SignError, SigningKey, sign, sign_with_fields};
 pub(crate) mod x25519;
 
 pub use curve25519_field::{Curve25519Field, Curve25519FieldCt};
@@ -261,5 +268,29 @@ where
         } else {
             Err(signature::Error::new())
         }
+    }
+}
+
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+impl<T> signature::Signer<[u8; 64]> for SigningKey<T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>
+        + core::ops::ShrAssign<usize>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    fn try_sign(&self, msg: &[u8]) -> Result<[u8; 64], signature::Error> {
+        sign::<T>(self, msg).map_err(|_| signature::Error::new())
     }
 }

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -131,6 +131,53 @@ impl<P: fixed_bigint::Personality> UnsignedModularInt for fixed_bigint::FixedUIn
     }
 }
 
+/// Aggregate bound bundle for the constant-time sign path: CT field
+/// arithmetic on Curve25519, byte (de)serialization, branchless
+/// selection, and `Zeroize` for secret-intermediate wiping.
+///
+/// `SigningKey<T>`, `sign`, `sign_with_fields`, and every CT point /
+/// scalar primitive in `strict_sign` would otherwise repeat the same
+/// 13-trait `where` clause. Auto-implemented for any backend that
+/// satisfies the listed bounds, so consumers don't write an explicit
+/// impl. The `for<'a> &'a T: …` HRTB stays at the call site because
+/// supertrait-elaboration of HRTBs is not yet reliable enough to
+/// propagate it automatically.
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+pub trait SignBackend:
+    UnsignedModularInt
+    + Copy
+    + PartialEq
+    + modmath::WideMul
+    + modmath::CiosMontMulCt
+    + modmath::Parity
+    + num_traits::WrappingMul
+    + num_traits::WrappingAdd
+    + num_traits::WrappingSub
+    + subtle::ConditionallySelectable
+    + subtle::ConstantTimeLess
+    + core::ops::Sub<Output = Self>
+    + zeroize::DefaultIsZeroes
+{
+}
+
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+impl<T> SignBackend for T where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>
+        + zeroize::DefaultIsZeroes
+{
+}
+
 // ED25519 constants
 pub const P_BYTES: [u8; 32] = [
     237, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255,
@@ -274,21 +321,7 @@ where
 #[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
 impl<T> signature::Signer<[u8; 64]> for SigningKey<T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>
-        + zeroize::DefaultIsZeroes,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     fn try_sign(&self, msg: &[u8]) -> Result<[u8; 64], signature::Error> {

--- a/ed25519/src/lib.rs
+++ b/ed25519/src/lib.rs
@@ -47,6 +47,8 @@ pub(crate) mod curve25519_field;
 pub(crate) mod jsf;
 #[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
 pub(crate) mod strict;
+#[cfg(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+pub(crate) mod strict_sign;
 pub(crate) mod x25519;
 
 pub use curve25519_field::{Curve25519Field, Curve25519FieldCt};

--- a/ed25519/src/scalar_field.rs
+++ b/ed25519/src/scalar_field.rs
@@ -1,0 +1,38 @@
+//! Factory for `modmath::FieldCt` over the Ed25519 scalar group order
+//! `q = 2^252 + 27742317777372353535851937790883648493`.
+//!
+//! Sign computes `s = (r + k·a) mod q` where all three operands are
+//! secret-derived, so the arithmetic runs on a `FieldCt<T>`. The
+//! lifetime brand on `ResidueCt<'f, T>` prevents q-field residues from
+//! flowing into a p-field operation — no separate type wrapper needed.
+//!
+//! `q` is odd and non-zero by construction; `modmath::FieldCt::new`
+//! still returns `Option` because it can't know which modulus we're
+//! passing. Discharge once at field construction.
+
+use crate::curve25519_field::CurveSetupError;
+use crate::{Q_BYTES, UnsignedModularInt};
+use modmath::{CiosMontMulCt, FieldCt, Parity, WideMul};
+
+pub fn curve25519_ct<T>() -> Result<FieldCt<T>, CurveSetupError>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + Parity
+        + WideMul
+        + CiosMontMulCt
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    if modmath::type_bit_width::<T>() < 256 {
+        return Err(CurveSetupError::BackendTooNarrow);
+    }
+    let q = T::from_bytes_le(&Q_BYTES);
+    FieldCt::new(q).ok_or(CurveSetupError::InvalidModulus)
+}

--- a/ed25519/src/signing_key.rs
+++ b/ed25519/src/signing_key.rs
@@ -58,7 +58,8 @@ where
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
         + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + zeroize::DefaultIsZeroes,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     /// Derive a signing key from a 32-byte seed (RFC 8032 §5.1.5).
@@ -115,7 +116,8 @@ where
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
         + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + zeroize::DefaultIsZeroes,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let p_field = Curve25519FieldCt::<T>::curve25519()?;
@@ -145,22 +147,26 @@ where
         + subtle::ConditionallySelectable
         + subtle::ConstantTimeLess
         + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>,
+        + core::ops::ShrAssign<usize>
+        + zeroize::DefaultIsZeroes,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let q = T::from_bytes_le(&Q_BYTES);
 
     // r = SHA-512(prefix || M) mod q. Secret-derived (prefix is part
-    // of the expanded key); CT reduction required.
-    let r = zeroize::Zeroizing::new(sha512_modq_ct::<T>(&[&*sk.prefix, msg], &q));
+    // of the expanded key); CT reduction required. `sha512_modq_ct`
+    // returns `Zeroizing<T>` so r is wiped on drop.
+    let r = sha512_modq_ct::<T>(&[&*sk.prefix, msg], &q);
 
-    // R = r · G, compressed. Public after this point.
+    // R = r · G, compressed. Public after this point — but the
+    // little-endian serialization of r passed to the ladder is still
+    // the secret nonce, so the scratch buffer must be zeroized.
     let g = base_point_ct(p_field);
     let mut r_bytes = zeroize::Zeroizing::new([0u8; 64]);
     let r_bytes_slice = r.to_bytes_le(&mut *r_bytes);
-    let mut r_le = [0u8; 32];
+    let mut r_le = zeroize::Zeroizing::new([0u8; 32]);
     r_le.copy_from_slice(&r_bytes_slice[..32]);
-    let r_point = scalar_mult_ct(p_field, &g, &r_le, 256);
+    let r_point = scalar_mult_ct(p_field, &g, &*r_le, 256);
     let r_encoded = point_compress_ct(&r_point, p_field);
 
     // k = SHA-512(R || A || M) mod q. Inputs are all public, but
@@ -172,7 +178,7 @@ where
     // FieldCt over q.
     let a_t = zeroize::Zeroizing::new(T::from_bytes_le(&*sk.a_bytes));
     let r_res = q_field.reduce(&*r);
-    let k_res = q_field.reduce(&k);
+    let k_res = q_field.reduce(&*k);
     let a_res = q_field.reduce(&*a_t);
     let ka = q_field.mul(&k_res, &a_res);
     let s_res = q_field.add(&r_res, &ka);

--- a/ed25519/src/signing_key.rs
+++ b/ed25519/src/signing_key.rs
@@ -1,0 +1,295 @@
+//! Ed25519 signing key and `sign` entry points (RFC 8032 §5.1.5–§5.1.6).
+//!
+//! The long-term seed expands into a clamped scalar `a` plus a nonce
+//! prefix; both are secrets and both live in `Zeroizing` wrappers
+//! whose `Drop` wipes the underlying bytes. Pubkey derivation runs
+//! once at `from_seed` time so each subsequent `sign` call performs a
+//! single scalar mult (for `R = r·G`) instead of two.
+
+use crate::curve25519_field::{Curve25519FieldCt, CurveSetupError};
+use crate::strict_sign::{base_point_ct, point_compress_ct, scalar_mult_ct, sha512_modq_ct};
+use crate::{Q_BYTES, UnsignedModularInt, scalar_field};
+use core::marker::PhantomData;
+use modmath::FieldCt;
+
+/// Errors from sign setup. `FieldSetup` covers the upstream
+/// `CurveSetupError` from p-field or q-field construction; both arms
+/// of `CurveSetupError` are unreachable for any well-formed backend,
+/// but the `Result` shape keeps the panic-fmt symbol out of the
+/// linked binary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SignError {
+    FieldSetup(CurveSetupError),
+}
+
+impl From<CurveSetupError> for SignError {
+    fn from(e: CurveSetupError) -> Self {
+        SignError::FieldSetup(e)
+    }
+}
+
+/// Ed25519 signing key. Holds the expanded clamped-scalar bytes and
+/// nonce-prefix (`Zeroizing`-wiped on drop) plus the cached encoded
+/// public key. The clamped scalar is stored as raw bytes rather than
+/// as a typed `T` so the struct stays generic over the backend
+/// without forcing `T: Zeroize` on the struct definition.
+pub struct SigningKey<T> {
+    /// Clamped scalar bytes derived from the seed. Long-term secret.
+    a_bytes: zeroize::Zeroizing<[u8; 32]>,
+    /// Nonce-derivation prefix from the seed. Long-term secret.
+    prefix: zeroize::Zeroizing<[u8; 32]>,
+    /// Compressed Edwards public key. Cached at construction.
+    public: [u8; 32],
+    _marker: PhantomData<T>,
+}
+
+impl<T> SigningKey<T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>
+        + core::ops::ShrAssign<usize>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    /// Derive a signing key from a 32-byte seed (RFC 8032 §5.1.5).
+    /// Runs `h = SHA-512(seed)`; splits into clamped scalar and nonce
+    /// prefix; computes and caches the compressed public key.
+    pub fn from_seed(seed: &[u8; 32]) -> Result<Self, SignError> {
+        let h = sha512(&[seed]);
+
+        let mut a_bytes = zeroize::Zeroizing::new([0u8; 32]);
+        a_bytes.copy_from_slice(&h[..32]);
+        // RFC 8032 §5.1.5: clamp the low 32 bytes.
+        a_bytes[0] &= 248;
+        a_bytes[31] &= 127;
+        a_bytes[31] |= 64;
+
+        let mut prefix = zeroize::Zeroizing::new([0u8; 32]);
+        prefix.copy_from_slice(&h[32..64]);
+
+        // Cache the compressed pubkey: A = a·G then compress.
+        let field = Curve25519FieldCt::<T>::curve25519()?;
+        let g = base_point_ct(&field);
+        let big_a = scalar_mult_ct(&field, &g, &*a_bytes, 256);
+        let public = point_compress_ct(&big_a, &field);
+
+        Ok(SigningKey {
+            a_bytes,
+            prefix,
+            public,
+            _marker: PhantomData,
+        })
+    }
+
+    /// Compressed Ed25519 public key (32 bytes).
+    pub fn public_key(&self) -> [u8; 32] {
+        self.public
+    }
+}
+
+/// Sign `msg` under `sk`. Builds the p-field and q-field internally;
+/// callers signing many messages with the same key should use
+/// [`sign_with_fields`] to amortize construction.
+pub fn sign<T>(sk: &SigningKey<T>, msg: &[u8]) -> Result<[u8; 64], SignError>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>
+        + core::ops::ShrAssign<usize>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    let p_field = Curve25519FieldCt::<T>::curve25519()?;
+    let q_field = scalar_field::curve25519_ct::<T>()?;
+    sign_with_fields(&p_field, &q_field, sk, msg)
+}
+
+/// Sign with pre-built p- and q-field instances. Amortizes the
+/// Montgomery precompute across many signs against the same key.
+pub fn sign_with_fields<T>(
+    p_field: &Curve25519FieldCt<T>,
+    q_field: &FieldCt<T>,
+    sk: &SigningKey<T>,
+    msg: &[u8],
+) -> Result<[u8; 64], SignError>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>
+        + core::ops::ShrAssign<usize>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    let q = T::from_bytes_le(&Q_BYTES);
+
+    // r = SHA-512(prefix || M) mod q. Secret-derived (prefix is part
+    // of the expanded key); CT reduction required.
+    let r = zeroize::Zeroizing::new(sha512_modq_ct::<T>(&[&*sk.prefix, msg], &q));
+
+    // R = r · G, compressed. Public after this point.
+    let g = base_point_ct(p_field);
+    let mut r_bytes = zeroize::Zeroizing::new([0u8; 64]);
+    let r_bytes_slice = r.to_bytes_le(&mut *r_bytes);
+    let mut r_le = [0u8; 32];
+    r_le.copy_from_slice(&r_bytes_slice[..32]);
+    let r_point = scalar_mult_ct(p_field, &g, &r_le, 256);
+    let r_encoded = point_compress_ct(&r_point, p_field);
+
+    // k = SHA-512(R || A || M) mod q. Inputs are all public, but
+    // running this through the CT helper keeps a single reduction
+    // path; the per-sign cost is one mod-q reduction.
+    let k = sha512_modq_ct::<T>(&[&r_encoded, &sk.public, msg], &q);
+
+    // s = (r + k · a) mod q. Every operand is secret-derived; runs on
+    // FieldCt over q.
+    let a_t = zeroize::Zeroizing::new(T::from_bytes_le(&*sk.a_bytes));
+    let r_res = q_field.reduce(&*r);
+    let k_res = q_field.reduce(&k);
+    let a_res = q_field.reduce(&*a_t);
+    let ka = q_field.mul(&k_res, &a_res);
+    let s_res = q_field.add(&r_res, &ka);
+    let s = q_field.into_raw(&s_res);
+
+    // Serialize s to 32 bytes (s < q < 2^253, fits with leading zeros).
+    let mut s_scratch = zeroize::Zeroizing::new([0u8; 64]);
+    let s_bytes_slice = s.to_bytes_le(&mut *s_scratch);
+
+    let mut sig = [0u8; 64];
+    sig[..32].copy_from_slice(&r_encoded);
+    sig[32..64].copy_from_slice(&s_bytes_slice[..32]);
+    Ok(sig)
+}
+
+// ---------------------------------------------------------------------------
+// SHA-512 helper (mirrors the backend selection used in `strict::sha512_modq`)
+// ---------------------------------------------------------------------------
+
+fn sha512(parts: &[&[u8]]) -> zeroize::Zeroizing<[u8; 64]> {
+    #[cfg(all(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+    compile_error!(
+        "ed25519_heapless: enable at most one SHA-512 backend feature — both `sha512-hmac-sha512` and `sha512-sha2` were enabled"
+    );
+    #[cfg(not(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2")))]
+    compile_error!(
+        "ed25519_heapless: enable exactly one of the SHA-512 backend features `sha512-hmac-sha512` or `sha512-sha2`"
+    );
+    #[cfg(all(feature = "sha512-hmac-sha512", not(feature = "sha512-sha2")))]
+    {
+        let mut compact_sha = hmac_sha512::Hash::new();
+        for part in parts {
+            compact_sha.update(part);
+        }
+        zeroize::Zeroizing::new(compact_sha.finalize())
+    }
+    #[cfg(all(feature = "sha512-sha2", not(feature = "sha512-hmac-sha512")))]
+    {
+        use sha2::Digest;
+        let mut compact_sha = sha2::Sha512::new();
+        for part in parts {
+            compact_sha.update(part);
+        }
+        zeroize::Zeroizing::new(compact_sha.finalize().into())
+    }
+}
+
+#[cfg(all(test, feature = "fixed-bigint"))]
+mod tests {
+    use super::*;
+    use fixed_bigint::FixedUInt;
+
+    type T = FixedUInt<u32, 16, fixed_bigint::Ct>;
+
+    /// RFC 8032 §7.1 test vector 1.
+    #[test]
+    fn rfc8032_test_1() {
+        let seed = hex_to_array("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+        let expected_public =
+            hex_to_array("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a");
+        let expected_sig = hex_to_64(
+            "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+        );
+        let msg: &[u8] = &[];
+
+        let sk = SigningKey::<T>::from_seed(&seed).expect("from_seed");
+        assert_eq!(sk.public_key(), expected_public, "pubkey mismatch");
+
+        let sig = sign(&sk, msg).expect("sign");
+        assert_eq!(sig, expected_sig, "signature mismatch");
+    }
+
+    /// RFC 8032 §7.1 test vector 2.
+    #[test]
+    fn rfc8032_test_2() {
+        let seed = hex_to_array("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb");
+        let expected_public =
+            hex_to_array("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c");
+        let expected_sig = hex_to_64(
+            "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+        );
+        let msg: &[u8] = &[0x72];
+
+        let sk = SigningKey::<T>::from_seed(&seed).expect("from_seed");
+        assert_eq!(sk.public_key(), expected_public);
+        assert_eq!(sign(&sk, msg).expect("sign"), expected_sig);
+    }
+
+    /// RFC 8032 §7.1 test vector 3.
+    #[test]
+    fn rfc8032_test_3() {
+        let seed = hex_to_array("c5aa8df43f9f837bedb7442f31dcb7b166d38535076f094b85ce3a2e0b4458f7");
+        let expected_public =
+            hex_to_array("fc51cd8e6218a1a38da47ed00230f0580816ed13ba3303ac5deb911548908025");
+        let expected_sig = hex_to_64(
+            "6291d657deec24024827e69c3abe01a30ce548a284743a445e3680d7db5ac3ac18ff9b538d16f290ae67f760984dc6594a7c15e9716ed28dc027beceea1ec40a",
+        );
+        let msg: &[u8] = &[0xaf, 0x82];
+
+        let sk = SigningKey::<T>::from_seed(&seed).expect("from_seed");
+        assert_eq!(sk.public_key(), expected_public);
+        assert_eq!(sign(&sk, msg).expect("sign"), expected_sig);
+    }
+
+    fn hex_to_array(s: &str) -> [u8; 32] {
+        let mut out = [0u8; 32];
+        for (i, b) in out.iter_mut().enumerate() {
+            *b = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).unwrap();
+        }
+        out
+    }
+
+    fn hex_to_64(s: &str) -> [u8; 64] {
+        let mut out = [0u8; 64];
+        for (i, b) in out.iter_mut().enumerate() {
+            *b = u8::from_str_radix(&s[i * 2..i * 2 + 2], 16).unwrap();
+        }
+        out
+    }
+}

--- a/ed25519/src/signing_key.rs
+++ b/ed25519/src/signing_key.rs
@@ -7,8 +7,10 @@
 //! single scalar mult (for `R = r·G`) instead of two.
 
 use crate::curve25519_field::{Curve25519FieldCt, CurveSetupError};
-use crate::strict_sign::{base_point_ct, point_compress_ct, scalar_mult_ct, sha512_modq_ct};
-use crate::{Q_BYTES, UnsignedModularInt, scalar_field};
+use crate::strict_sign::{
+    base_point_ct, point_compress_ct, scalar_mult_ct, sha512, sha512_modq_ct,
+};
+use crate::{Q_BYTES, SignBackend, scalar_field};
 use core::marker::PhantomData;
 use modmath::FieldCt;
 
@@ -45,21 +47,7 @@ pub struct SigningKey<T> {
 
 impl<T> SigningKey<T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>
-        + zeroize::DefaultIsZeroes,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     /// Derive a signing key from a 32-byte seed (RFC 8032 §5.1.5).
@@ -81,7 +69,7 @@ where
         // Cache the compressed pubkey: A = a·G then compress.
         let field = Curve25519FieldCt::<T>::curve25519()?;
         let g = base_point_ct(&field);
-        let big_a = scalar_mult_ct(&field, &g, &*a_bytes, 256);
+        let big_a = scalar_mult_ct(&field, &g, &*a_bytes);
         let public = point_compress_ct(&big_a, &field);
 
         Ok(SigningKey {
@@ -103,21 +91,7 @@ where
 /// [`sign_with_fields`] to amortize construction.
 pub fn sign<T>(sk: &SigningKey<T>, msg: &[u8]) -> Result<[u8; 64], SignError>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>
-        + zeroize::DefaultIsZeroes,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let p_field = Curve25519FieldCt::<T>::curve25519()?;
@@ -134,21 +108,7 @@ pub fn sign_with_fields<T>(
     msg: &[u8],
 ) -> Result<[u8; 64], SignError>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>
-        + zeroize::DefaultIsZeroes,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let q = T::from_bytes_le(&Q_BYTES);
@@ -166,7 +126,7 @@ where
     let r_bytes_slice = r.to_bytes_le(&mut *r_bytes);
     let mut r_le = zeroize::Zeroizing::new([0u8; 32]);
     r_le.copy_from_slice(&r_bytes_slice[..32]);
-    let r_point = scalar_mult_ct(p_field, &g, &*r_le, 256);
+    let r_point = scalar_mult_ct(p_field, &g, &*r_le);
     let r_encoded = point_compress_ct(&r_point, p_field);
 
     // k = SHA-512(R || A || M) mod q. Inputs are all public, but
@@ -192,38 +152,6 @@ where
     sig[..32].copy_from_slice(&r_encoded);
     sig[32..64].copy_from_slice(&s_bytes_slice[..32]);
     Ok(sig)
-}
-
-// ---------------------------------------------------------------------------
-// SHA-512 helper (mirrors the backend selection used in `strict::sha512_modq`)
-// ---------------------------------------------------------------------------
-
-fn sha512(parts: &[&[u8]]) -> zeroize::Zeroizing<[u8; 64]> {
-    #[cfg(all(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
-    compile_error!(
-        "ed25519_heapless: enable at most one SHA-512 backend feature — both `sha512-hmac-sha512` and `sha512-sha2` were enabled"
-    );
-    #[cfg(not(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2")))]
-    compile_error!(
-        "ed25519_heapless: enable exactly one of the SHA-512 backend features `sha512-hmac-sha512` or `sha512-sha2`"
-    );
-    #[cfg(all(feature = "sha512-hmac-sha512", not(feature = "sha512-sha2")))]
-    {
-        let mut compact_sha = hmac_sha512::Hash::new();
-        for part in parts {
-            compact_sha.update(part);
-        }
-        zeroize::Zeroizing::new(compact_sha.finalize())
-    }
-    #[cfg(all(feature = "sha512-sha2", not(feature = "sha512-hmac-sha512")))]
-    {
-        use sha2::Digest;
-        let mut compact_sha = sha2::Sha512::new();
-        for part in parts {
-            compact_sha.update(part);
-        }
-        zeroize::Zeroizing::new(compact_sha.finalize().into())
-    }
 }
 
 #[cfg(all(test, feature = "fixed-bigint"))]

--- a/ed25519/src/strict_sign.rs
+++ b/ed25519/src/strict_sign.rs
@@ -1,0 +1,298 @@
+//! Ed25519 signing primitives — CT counterparts of the point ops in
+//! [`crate::strict`].
+//!
+//! Verify operates on public inputs; its NAF double-scalar mult is
+//! variable-time. Sign operates on the long-term secret scalar `a` and
+//! a per-signature secret nonce `r`. Both scalars must drive a CT
+//! single-scalar multiplication on the Edwards curve, so the point
+//! arithmetic and the ladder live here in `ResidueCt` form.
+
+// Phase 1 of sign-pr-a lands the CT point ops and scalar mult with
+// only in-module unit tests as consumers. The public `sign()` /
+// `SigningKey` API consumes these in phase 2; until then suppress the
+// dead-code lint at the module level.
+#![allow(dead_code)]
+
+use crate::curve25519_field::Curve25519FieldCt;
+use crate::{D_BYTES, UnsignedModularInt};
+use modmath::ResidueCt;
+use subtle::Choice;
+
+// =========================================================================
+// Type aliases — CT analogs of strict.rs's EdPoint / NielsPoint
+// =========================================================================
+
+pub(crate) type EdPointCt<'f, T> = (
+    ResidueCt<'f, T>,
+    ResidueCt<'f, T>,
+    ResidueCt<'f, T>,
+    ResidueCt<'f, T>,
+);
+
+pub(crate) type NielsPointCt<'f, T> = (ResidueCt<'f, T>, ResidueCt<'f, T>, ResidueCt<'f, T>);
+
+// =========================================================================
+// Point operations on Curve25519FieldCt
+// =========================================================================
+
+#[inline(never)]
+pub(crate) fn point_double_ct<'f, T>(
+    pp: &EdPointCt<'f, T>,
+    field: &'f Curve25519FieldCt<T>,
+) -> EdPointCt<'f, T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    // a = X²; b = Y²; c = 2·Z²; d = −A (a = −1 for Ed25519)
+    // e = (X+Y)² − a − b; g = d + b; f = g − c; h = d − b
+    // X' = e·f; Y' = g·h; Z' = f·g; T' = e·h
+    let a = field.mul(&pp.0, &pp.0);
+    let b = field.mul(&pp.1, &pp.1);
+    let z_sq = field.mul(&pp.2, &pp.2);
+    let c = field.add(&z_sq, &z_sq);
+    let zero = field.zero();
+    let d = field.sub(&zero, &a);
+    let x_plus_y = field.add(&pp.0, &pp.1);
+    let xy_sq = field.mul(&x_plus_y, &x_plus_y);
+    let e_tmp = field.sub(&xy_sq, &a);
+    let e = field.sub(&e_tmp, &b);
+    let g = field.add(&d, &b);
+    let f = field.sub(&g, &c);
+    let h = field.sub(&d, &b);
+    (
+        field.mul(&e, &f),
+        field.mul(&g, &h),
+        field.mul(&f, &g),
+        field.mul(&e, &h),
+    )
+}
+
+pub(crate) fn to_niels_ct<'f, T>(
+    pp: &EdPointCt<'f, T>,
+    d_raw: T,
+    field: &'f Curve25519FieldCt<T>,
+) -> NielsPointCt<'f, T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    let y_plus_x = field.add(&pp.1, &pp.0);
+    let y_minus_x = field.sub(&pp.1, &pp.0);
+    let d = field.reduce(&d_raw);
+    let dt = field.mul(&d, &pp.3);
+    let two_dt = field.add(&dt, &dt);
+    (y_plus_x, y_minus_x, two_dt)
+}
+
+#[inline(never)]
+pub(crate) fn point_add_niels_ct<'f, T>(
+    pp: &EdPointCt<'f, T>,
+    niels: &NielsPointCt<'f, T>,
+    field: &'f Curve25519FieldCt<T>,
+) -> EdPointCt<'f, T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    // A = (Y₁−X₁)·(y−x); B = (Y₁+X₁)·(y+x); C = T₁·2dt; D = 2·Z₁
+    let pp_y_minus_x = field.sub(&pp.1, &pp.0);
+    let a = field.mul(&pp_y_minus_x, &niels.1);
+    let pp_y_plus_x = field.add(&pp.1, &pp.0);
+    let b = field.mul(&pp_y_plus_x, &niels.0);
+    let c = field.mul(&pp.3, &niels.2);
+    let d = field.add(&pp.2, &pp.2);
+    // E = B − A; F = D − C; G = D + C; H = B + A
+    let e = field.sub(&b, &a);
+    let f = field.sub(&d, &c);
+    let g = field.add(&d, &c);
+    let h = field.add(&b, &a);
+    (
+        field.mul(&e, &f),
+        field.mul(&g, &h),
+        field.mul(&f, &g),
+        field.mul(&e, &h),
+    )
+}
+
+/// Branchless conditional swap of two Edwards points. Identical-shape
+/// to the cswap on Montgomery ladder state in x25519, just applied to
+/// each of the four extended-twisted projective coords.
+#[inline]
+pub(crate) fn point_cswap_ct<'f, T>(
+    choice: Choice,
+    a: &mut EdPointCt<'f, T>,
+    b: &mut EdPointCt<'f, T>,
+) where
+    T: subtle::ConditionallySelectable + modmath::MontStorage,
+{
+    ResidueCt::cswap(choice, &mut a.0, &mut b.0);
+    ResidueCt::cswap(choice, &mut a.1, &mut b.1);
+    ResidueCt::cswap(choice, &mut a.2, &mut b.2);
+    ResidueCt::cswap(choice, &mut a.3, &mut b.3);
+}
+
+// =========================================================================
+// CT scalar multiplication on the Edwards curve
+// =========================================================================
+
+/// `k · base` on the Edwards curve. Branchless Montgomery-ladder shape
+/// on extended-twisted projective points. Constant-time with respect
+/// to `k`: every iteration runs one doubling + one niels addition and
+/// one cswap; the cswap pattern matches the scalar bit but does not
+/// branch on it.
+///
+/// `scalar` is read MSB-first across `bit_count` bits. Leading zero
+/// bits are CT-safe — the cswap stays at identity until the first set
+/// bit appears, after which the accumulator carries the partial sum.
+#[inline(never)]
+pub(crate) fn scalar_mult_ct<'f, T>(
+    field: &'f Curve25519FieldCt<T>,
+    base: &EdPointCt<'f, T>,
+    scalar: &[u8],
+    bit_count: usize,
+) -> EdPointCt<'f, T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    let d_raw = T::from_bytes_le(&D_BYTES);
+    let base_niels = to_niels_ct(base, d_raw, field);
+
+    // Identity in extended-twisted Edwards: (0, 1, 1, 0).
+    let mut acc: EdPointCt<'f, T> = (field.zero(), field.one(), field.one(), field.zero());
+
+    for t in (0..bit_count).rev() {
+        acc = point_double_ct(&acc, field);
+        let bit = (scalar[t >> 3] >> (t & 7)) & 1;
+        // "Add-always" via CT cswap: compute the sum, then conditionally
+        // swap it into the accumulator based on the bit.
+        let mut sum = point_add_niels_ct(&acc, &base_niels, field);
+        point_cswap_ct(Choice::from(bit), &mut acc, &mut sum);
+    }
+
+    acc
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+#[cfg(all(test, feature = "fixed-bigint"))]
+mod tests {
+    use super::*;
+    use crate::curve25519_field::Curve25519FieldCt;
+    use crate::{G_T_BYTES, G_X_BYTES, G_Y_BYTES};
+    use fixed_bigint::FixedUInt;
+
+    type T = FixedUInt<u32, 16, fixed_bigint::Ct>;
+
+    fn base_point_ct<'f>(field: &'f Curve25519FieldCt<T>) -> EdPointCt<'f, T> {
+        let gx = field.reduce(&T::from_bytes_le(&G_X_BYTES));
+        let gy = field.reduce(&T::from_bytes_le(&G_Y_BYTES));
+        let one = field.one();
+        let gt = field.reduce(&T::from_bytes_le(&G_T_BYTES));
+        (gx, gy, one, gt)
+    }
+
+    /// Two projective points are geometrically equal iff
+    /// `X1·Z2 == X2·Z1` and `Y1·Z2 == Y2·Z1`. Comparing the projective
+    /// coordinates directly would miss equivalent representations.
+    fn projective_eq<'f>(
+        a: &EdPointCt<'f, T>,
+        b: &EdPointCt<'f, T>,
+        field: &'f Curve25519FieldCt<T>,
+    ) -> bool {
+        let lhs_x = field.mul(&a.0, &b.2);
+        let rhs_x = field.mul(&b.0, &a.2);
+        let lhs_y = field.mul(&a.1, &b.2);
+        let rhs_y = field.mul(&b.1, &a.2);
+        lhs_x == rhs_x && lhs_y == rhs_y
+    }
+
+    #[test]
+    fn double_matches_add_self() {
+        let field = Curve25519FieldCt::<T>::curve25519().unwrap();
+        let g = base_point_ct(&field);
+        let d_raw = T::from_bytes_le(&D_BYTES);
+        let g_niels = to_niels_ct(&g, d_raw, &field);
+
+        let doubled = point_double_ct(&g, &field);
+        let added = point_add_niels_ct(&g, &g_niels, &field);
+
+        assert!(projective_eq(&doubled, &added, &field));
+    }
+
+    #[test]
+    fn scalar_mult_by_one_returns_base() {
+        let field = Curve25519FieldCt::<T>::curve25519().unwrap();
+        let g = base_point_ct(&field);
+
+        let mut scalar = [0u8; 32];
+        scalar[0] = 1;
+        let result = scalar_mult_ct(&field, &g, &scalar, 256);
+
+        assert!(projective_eq(&result, &g, &field));
+    }
+
+    #[test]
+    fn scalar_mult_by_two_matches_double() {
+        let field = Curve25519FieldCt::<T>::curve25519().unwrap();
+        let g = base_point_ct(&field);
+
+        let mut scalar = [0u8; 32];
+        scalar[0] = 2;
+        let result = scalar_mult_ct(&field, &g, &scalar, 256);
+        let doubled = point_double_ct(&g, &field);
+
+        assert!(projective_eq(&result, &doubled, &field));
+    }
+}

--- a/ed25519/src/strict_sign.rs
+++ b/ed25519/src/strict_sign.rs
@@ -7,12 +7,6 @@
 //! single-scalar multiplication on the Edwards curve, so the point
 //! arithmetic and the ladder live here in `ResidueCt` form.
 
-// Phase 1 of sign-pr-a lands the CT point ops and scalar mult with
-// only in-module unit tests as consumers. The public `sign()` /
-// `SigningKey` API consumes these in phase 2; until then suppress the
-// dead-code lint at the module level.
-#![allow(dead_code)]
-
 use crate::curve25519_field::Curve25519FieldCt;
 use crate::{D_BYTES, UnsignedModularInt};
 use modmath::ResidueCt;
@@ -223,25 +217,176 @@ where
 }
 
 // =========================================================================
+// Point compression
+// =========================================================================
+
+/// Encode an extended-twisted projective Edwards point as 32 bytes
+/// per RFC 8032 §5.1.2. Computes affine `(x, y)` via one inversion,
+/// emits `y` little-endian with the high bit of byte 31 set to the
+/// parity of `x`.
+pub(crate) fn point_compress_ct<'f, T>(
+    pp: &EdPointCt<'f, T>,
+    field: &'f Curve25519FieldCt<T>,
+) -> [u8; 32]
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess
+        + core::ops::Sub<Output = T>
+        + core::ops::ShrAssign<usize>,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    const {
+        // x25519.rs caps T at 64 bytes; the same bound applies here so
+        // the scratch buffer below can be a stack array.
+        assert!(core::mem::size_of::<T>() <= 64);
+    }
+
+    let z_inv = field.inv(&pp.2);
+    let x = field.mul(&pp.0, &z_inv);
+    let y = field.mul(&pp.1, &z_inv);
+
+    let x_raw = field.into_raw(&x);
+    let y_raw = field.into_raw(&y);
+
+    let parity = (x_raw & T::one()) == T::one();
+
+    // T may be wider than 32 bytes (e.g. FixedUInt<u32, 16> is 64
+    // bytes); to_bytes_le needs a buffer matching T's width. y < p <
+    // 2^255 fits in the low 32 bytes, the rest is zero.
+    let mut scratch = zeroize::Zeroizing::new([0u8; 64]);
+    let bytes = y_raw.to_bytes_le(&mut *scratch);
+    let mut out = [0u8; 32];
+    out.copy_from_slice(&bytes[..32]);
+    // RFC 8032 §5.1.2: y is 255 bits; the high bit of byte 31 carries
+    // the parity of x. y < p < 2^255 so bit 7 of byte 31 is zero before
+    // we OR in the parity.
+    out[31] |= (parity as u8) << 7;
+    out
+}
+
+// =========================================================================
+// CT scalar reduction mod q
+// =========================================================================
+
+/// `SHA-512(parts...) mod q`, constant-time over the hash bytes. Sign
+/// derives its per-signature nonce `r = SHA-512(prefix || M) mod q`
+/// where the input is secret-dependent (`prefix` is part of the
+/// expanded long-term key), so the modular reduction has to be CT.
+///
+/// Same bit-by-bit Horner as `strict::sha512_modq`, but every branch
+/// becomes a `subtle::ConditionallySelectable` choice on `T`.
+#[inline(never)]
+pub(crate) fn sha512_modq_ct<T>(parts: &[&[u8]], q: &T) -> T
+where
+    T: UnsignedModularInt
+        + Copy
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    #[cfg(all(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+    compile_error!(
+        "ed25519_heapless: enable at most one SHA-512 backend feature — both `sha512-hmac-sha512` and `sha512-sha2` were enabled"
+    );
+    #[cfg(not(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2")))]
+    compile_error!(
+        "ed25519_heapless: enable exactly one of the SHA-512 backend features `sha512-hmac-sha512` or `sha512-sha2`"
+    );
+    #[cfg(all(feature = "sha512-hmac-sha512", not(feature = "sha512-sha2")))]
+    let hash: zeroize::Zeroizing<[u8; 64]> = {
+        let mut compact_sha = hmac_sha512::Hash::new();
+        for part in parts {
+            compact_sha.update(part);
+        }
+        zeroize::Zeroizing::new(compact_sha.finalize())
+    };
+    #[cfg(all(feature = "sha512-sha2", not(feature = "sha512-hmac-sha512")))]
+    let hash: zeroize::Zeroizing<[u8; 64]> = {
+        use sha2::Digest;
+        let mut compact_sha = sha2::Sha512::new();
+        for part in parts {
+            compact_sha.update(part);
+        }
+        zeroize::Zeroizing::new(compact_sha.finalize().into())
+    };
+
+    let zero = T::zero();
+    let one = T::one();
+    let mut acc = T::zero();
+
+    for byte_idx in (0..64).rev() {
+        for bit_idx in (0..8).rev() {
+            // acc *= 2
+            let (doubled, _overflow) = acc.overflowing_add(&acc);
+            acc = doubled;
+
+            // acc += bit (branchlessly)
+            let bit_val = (hash[byte_idx] >> bit_idx) & 1;
+            let bit_t = T::conditional_select(&zero, &one, Choice::from(bit_val));
+            let (with_bit, _) = acc.overflowing_add(&bit_t);
+            acc = with_bit;
+
+            // CT reduce: acc < 2q + 1 after the increment, so at most
+            // two conditional subtractions reach the canonical range.
+            for _ in 0..2 {
+                let candidate = acc.wrapping_sub(q);
+                let needs_sub = !acc.ct_lt(q);
+                acc = T::conditional_select(&acc, &candidate, needs_sub);
+            }
+        }
+    }
+    acc
+}
+
+// =========================================================================
 // Tests
 // =========================================================================
+
+/// The Ed25519 base point `G` in extended-twisted projective form
+/// over a CT field instance. Constants from `G_X_BYTES` / `G_Y_BYTES`
+/// / `G_T_BYTES`, projective `Z = 1`.
+pub(crate) fn base_point_ct<'f, T>(field: &'f Curve25519FieldCt<T>) -> EdPointCt<'f, T>
+where
+    T: UnsignedModularInt
+        + Copy
+        + PartialEq
+        + modmath::WideMul
+        + modmath::CiosMontMulCt
+        + modmath::Parity
+        + num_traits::ops::overflowing::OverflowingAdd
+        + num_traits::WrappingMul
+        + num_traits::WrappingAdd
+        + num_traits::WrappingSub
+        + subtle::ConditionallySelectable
+        + subtle::ConstantTimeLess,
+    for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
+{
+    let gx = field.reduce(&T::from_bytes_le(&crate::G_X_BYTES));
+    let gy = field.reduce(&T::from_bytes_le(&crate::G_Y_BYTES));
+    let one = field.one();
+    let gt = field.reduce(&T::from_bytes_le(&crate::G_T_BYTES));
+    (gx, gy, one, gt)
+}
 
 #[cfg(all(test, feature = "fixed-bigint"))]
 mod tests {
     use super::*;
     use crate::curve25519_field::Curve25519FieldCt;
-    use crate::{G_T_BYTES, G_X_BYTES, G_Y_BYTES};
     use fixed_bigint::FixedUInt;
 
     type T = FixedUInt<u32, 16, fixed_bigint::Ct>;
-
-    fn base_point_ct<'f>(field: &'f Curve25519FieldCt<T>) -> EdPointCt<'f, T> {
-        let gx = field.reduce(&T::from_bytes_le(&G_X_BYTES));
-        let gy = field.reduce(&T::from_bytes_le(&G_Y_BYTES));
-        let one = field.one();
-        let gt = field.reduce(&T::from_bytes_le(&G_T_BYTES));
-        (gx, gy, one, gt)
-    }
 
     /// Two projective points are geometrically equal iff
     /// `X1·Z2 == X2·Z1` and `Y1·Z2 == Y2·Z1`. Comparing the projective

--- a/ed25519/src/strict_sign.rs
+++ b/ed25519/src/strict_sign.rs
@@ -285,11 +285,16 @@ where
 ///
 /// Same bit-by-bit Horner as `strict::sha512_modq`, but every branch
 /// becomes a `subtle::ConditionallySelectable` choice on `T`.
+// Returns `Zeroizing<T>` so the intermediate accumulator — which transits
+// the secret nonce `r` when called over `prefix || M` — is wiped on drop,
+// closing the nonce-leak surface that would otherwise let an attacker
+// solve `a = (s - r) · k⁻¹ mod q` from a memory disclosure.
 #[inline(never)]
-pub(crate) fn sha512_modq_ct<T>(parts: &[&[u8]], q: &T) -> T
+pub(crate) fn sha512_modq_ct<T>(parts: &[&[u8]], q: &T) -> zeroize::Zeroizing<T>
 where
     T: UnsignedModularInt
         + Copy
+        + zeroize::DefaultIsZeroes
         + num_traits::ops::overflowing::OverflowingAdd
         + num_traits::WrappingSub
         + subtle::ConditionallySelectable
@@ -324,26 +329,26 @@ where
 
     let zero = T::zero();
     let one = T::one();
-    let mut acc = T::zero();
+    let mut acc = zeroize::Zeroizing::new(T::zero());
 
     for byte_idx in (0..64).rev() {
         for bit_idx in (0..8).rev() {
             // acc *= 2
-            let (doubled, _overflow) = acc.overflowing_add(&acc);
-            acc = doubled;
+            let (doubled, _overflow) = acc.overflowing_add(&*acc);
+            *acc = doubled;
 
             // acc += bit (branchlessly)
             let bit_val = (hash[byte_idx] >> bit_idx) & 1;
             let bit_t = T::conditional_select(&zero, &one, Choice::from(bit_val));
             let (with_bit, _) = acc.overflowing_add(&bit_t);
-            acc = with_bit;
+            *acc = with_bit;
 
             // CT reduce: acc < 2q + 1 after the increment, so at most
             // two conditional subtractions reach the canonical range.
             for _ in 0..2 {
                 let candidate = acc.wrapping_sub(q);
                 let needs_sub = !acc.ct_lt(q);
-                acc = T::conditional_select(&acc, &candidate, needs_sub);
+                *acc = T::conditional_select(&*acc, &candidate, needs_sub);
             }
         }
     }

--- a/ed25519/src/strict_sign.rs
+++ b/ed25519/src/strict_sign.rs
@@ -8,9 +8,46 @@
 //! arithmetic and the ladder live here in `ResidueCt` form.
 
 use crate::curve25519_field::Curve25519FieldCt;
-use crate::{D_BYTES, UnsignedModularInt};
+use crate::{D_BYTES, SignBackend};
 use modmath::ResidueCt;
 use subtle::Choice;
+
+// =========================================================================
+// Shared SHA-512 helper — single source of cfg-gated backend selection
+// =========================================================================
+
+/// SHA-512 over the concatenation of `parts`. Single definition of the
+/// `sha512-hmac-sha512` vs `sha512-sha2` backend choice, used by every
+/// sign-path consumer (`sha512_modq_ct` here and `from_seed` in
+/// `signing_key`). Output goes in `Zeroizing` because callers feed it
+/// secret-derived material (the seed and the nonce prefix).
+pub(crate) fn sha512(parts: &[&[u8]]) -> zeroize::Zeroizing<[u8; 64]> {
+    #[cfg(all(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
+    compile_error!(
+        "ed25519_heapless: enable at most one SHA-512 backend feature — both `sha512-hmac-sha512` and `sha512-sha2` were enabled"
+    );
+    #[cfg(not(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2")))]
+    compile_error!(
+        "ed25519_heapless: enable exactly one of the SHA-512 backend features `sha512-hmac-sha512` or `sha512-sha2`"
+    );
+    #[cfg(all(feature = "sha512-hmac-sha512", not(feature = "sha512-sha2")))]
+    {
+        let mut compact_sha = hmac_sha512::Hash::new();
+        for part in parts {
+            compact_sha.update(part);
+        }
+        zeroize::Zeroizing::new(compact_sha.finalize())
+    }
+    #[cfg(all(feature = "sha512-sha2", not(feature = "sha512-hmac-sha512")))]
+    {
+        use sha2::Digest;
+        let mut compact_sha = sha2::Sha512::new();
+        for part in parts {
+            compact_sha.update(part);
+        }
+        zeroize::Zeroizing::new(compact_sha.finalize().into())
+    }
+}
 
 // =========================================================================
 // Type aliases — CT analogs of strict.rs's EdPoint / NielsPoint
@@ -35,19 +72,7 @@ pub(crate) fn point_double_ct<'f, T>(
     field: &'f Curve25519FieldCt<T>,
 ) -> EdPointCt<'f, T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     // a = X²; b = Y²; c = 2·Z²; d = −A (a = −1 for Ed25519)
@@ -80,19 +105,7 @@ pub(crate) fn to_niels_ct<'f, T>(
     field: &'f Curve25519FieldCt<T>,
 ) -> NielsPointCt<'f, T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let y_plus_x = field.add(&pp.1, &pp.0);
@@ -110,19 +123,7 @@ pub(crate) fn point_add_niels_ct<'f, T>(
     field: &'f Curve25519FieldCt<T>,
 ) -> EdPointCt<'f, T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     // A = (Y₁−X₁)·(y−x); B = (Y₁+X₁)·(y+x); C = T₁·2dt; D = 2·Z₁
@@ -172,30 +173,18 @@ pub(crate) fn point_cswap_ct<'f, T>(
 /// one cswap; the cswap pattern matches the scalar bit but does not
 /// branch on it.
 ///
-/// `scalar` is read MSB-first across `bit_count` bits. Leading zero
-/// bits are CT-safe — the cswap stays at identity until the first set
-/// bit appears, after which the accumulator carries the partial sum.
+/// `scalar` is read MSB-first across `scalar.len() * 8` bits. Leading
+/// zero bits are CT-safe — the cswap stays at identity until the first
+/// set bit appears, after which the accumulator carries the partial
+/// sum.
 #[inline(never)]
 pub(crate) fn scalar_mult_ct<'f, T>(
     field: &'f Curve25519FieldCt<T>,
     base: &EdPointCt<'f, T>,
     scalar: &[u8],
-    bit_count: usize,
 ) -> EdPointCt<'f, T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let d_raw = T::from_bytes_le(&D_BYTES);
@@ -204,6 +193,7 @@ where
     // Identity in extended-twisted Edwards: (0, 1, 1, 0).
     let mut acc: EdPointCt<'f, T> = (field.zero(), field.one(), field.one(), field.zero());
 
+    let bit_count = scalar.len() * 8;
     for t in (0..bit_count).rev() {
         acc = point_double_ct(&acc, field);
         let bit = (scalar[t >> 3] >> (t & 7)) & 1;
@@ -229,20 +219,7 @@ pub(crate) fn point_compress_ct<'f, T>(
     field: &'f Curve25519FieldCt<T>,
 ) -> [u8; 32]
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess
-        + core::ops::Sub<Output = T>
-        + core::ops::ShrAssign<usize>,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     const {
@@ -292,40 +269,10 @@ where
 #[inline(never)]
 pub(crate) fn sha512_modq_ct<T>(parts: &[&[u8]], q: &T) -> zeroize::Zeroizing<T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + zeroize::DefaultIsZeroes
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
-    #[cfg(all(feature = "sha512-hmac-sha512", feature = "sha512-sha2"))]
-    compile_error!(
-        "ed25519_heapless: enable at most one SHA-512 backend feature — both `sha512-hmac-sha512` and `sha512-sha2` were enabled"
-    );
-    #[cfg(not(any(feature = "sha512-hmac-sha512", feature = "sha512-sha2")))]
-    compile_error!(
-        "ed25519_heapless: enable exactly one of the SHA-512 backend features `sha512-hmac-sha512` or `sha512-sha2`"
-    );
-    #[cfg(all(feature = "sha512-hmac-sha512", not(feature = "sha512-sha2")))]
-    let hash: zeroize::Zeroizing<[u8; 64]> = {
-        let mut compact_sha = hmac_sha512::Hash::new();
-        for part in parts {
-            compact_sha.update(part);
-        }
-        zeroize::Zeroizing::new(compact_sha.finalize())
-    };
-    #[cfg(all(feature = "sha512-sha2", not(feature = "sha512-hmac-sha512")))]
-    let hash: zeroize::Zeroizing<[u8; 64]> = {
-        use sha2::Digest;
-        let mut compact_sha = sha2::Sha512::new();
-        for part in parts {
-            compact_sha.update(part);
-        }
-        zeroize::Zeroizing::new(compact_sha.finalize().into())
-    };
+    let hash = sha512(parts);
 
     let zero = T::zero();
     let one = T::one();
@@ -364,18 +311,7 @@ where
 /// / `G_T_BYTES`, projective `Z = 1`.
 pub(crate) fn base_point_ct<'f, T>(field: &'f Curve25519FieldCt<T>) -> EdPointCt<'f, T>
 where
-    T: UnsignedModularInt
-        + Copy
-        + PartialEq
-        + modmath::WideMul
-        + modmath::CiosMontMulCt
-        + modmath::Parity
-        + num_traits::ops::overflowing::OverflowingAdd
-        + num_traits::WrappingMul
-        + num_traits::WrappingAdd
-        + num_traits::WrappingSub
-        + subtle::ConditionallySelectable
-        + subtle::ConstantTimeLess,
+    T: SignBackend,
     for<'a> &'a T: core::ops::Add<&'a T, Output = T> + core::ops::Sub<&'a T, Output = T>,
 {
     let gx = field.reduce(&T::from_bytes_le(&crate::G_X_BYTES));
@@ -388,6 +324,7 @@ where
 #[cfg(all(test, feature = "fixed-bigint"))]
 mod tests {
     use super::*;
+    use crate::UnsignedModularInt;
     use crate::curve25519_field::Curve25519FieldCt;
     use fixed_bigint::FixedUInt;
 
@@ -428,7 +365,7 @@ mod tests {
 
         let mut scalar = [0u8; 32];
         scalar[0] = 1;
-        let result = scalar_mult_ct(&field, &g, &scalar, 256);
+        let result = scalar_mult_ct(&field, &g, &scalar);
 
         assert!(projective_eq(&result, &g, &field));
     }
@@ -440,7 +377,7 @@ mod tests {
 
         let mut scalar = [0u8; 32];
         scalar[0] = 2;
-        let result = scalar_mult_ct(&field, &g, &scalar, 256);
+        let result = scalar_mult_ct(&field, &g, &scalar);
         let doubled = point_double_ct(&g, &field);
 
         assert!(projective_eq(&result, &doubled, &field));

--- a/ed25519/tests/signature_traits.rs
+++ b/ed25519/tests/signature_traits.rs
@@ -4,10 +4,14 @@
 
 #![cfg(feature = "fixed-bigint")]
 
-use ed25519_heapless::VerifyingKey;
-use signature::Verifier;
+use ed25519_heapless::{SigningKey, VerifyingKey};
+use signature::{Signer, Verifier};
 
 type T = fixed_bigint::FixedUInt<u32, 16>;
+// Sign requires the constant-time backend mode; verify is happy with
+// either. Keep both aliases so each test exercises the realistic
+// configuration for its operation.
+type Tct = fixed_bigint::FixedUInt<u32, 16, fixed_bigint::Ct>;
 
 struct SigWrapper(Vec<u8>);
 
@@ -55,4 +59,34 @@ fn verifier_rejects_signature_with_invalid_length() {
     let signature = SigWrapper(vec![0u8; 63]);
 
     assert!(verifying_key.verify(b"", &signature).is_err());
+}
+
+#[test]
+fn signer_matches_rfc8032_test1() {
+    let seed = hex_to_array_32("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+    let sk = SigningKey::<Tct>::from_seed(&seed).expect("from_seed");
+
+    let sig: [u8; 64] = sk.try_sign(b"").expect("try_sign");
+    let expected = rfc_test1_signature();
+    assert_eq!(&sig[..], &expected[..]);
+}
+
+#[test]
+fn signer_verifier_roundtrip() {
+    // Distinct from the RFC fixed-vector tests: exercises the trait
+    // surface end-to-end across several message shapes, including the
+    // multi-block SHA-512 boundary.
+    let seed = hex_to_array_32("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb");
+    let sk = SigningKey::<Tct>::from_seed(&seed).expect("from_seed");
+    let vk = VerifyingKey::<T>::from_bytes(sk.public_key());
+
+    for msg in [
+        b"".as_slice(),
+        b"a".as_slice(),
+        &[0xff; 32][..],
+        &[0x55; 129][..],
+    ] {
+        let sig: [u8; 64] = sk.try_sign(msg).expect("try_sign");
+        vk.verify(msg, &sig).expect("verify");
+    }
 }


### PR DESCRIPTION
## Summary

Adds Ed25519 signing (RFC 8032 pure variant) on top of the existing verify-only crate, constant-time from the start.

- **`SigningKey<T>::from_seed`** — SHA-512 seed expansion, RFC §5.1.5 scalar clamping, cached compressed public key. Clamped scalar and nonce prefix live in `Zeroizing` wrappers.
- **`sign` / `sign_with_fields`** — produces a 64-byte signature. `sign_with_fields` lets callers amortize p-field and q-field setup across many signatures with the same key.
- **CT scalar mult** (`strict_sign.rs`) — add-always Montgomery-ladder shape on extended-twisted projective points, branchless cswap on each iteration. Used for both `A = a·G` (pubkey derivation) and `R = r·G` (per-signature nonce point).
- **Scalar-field arithmetic** (`scalar_field::curve25519_ct`) — `FieldCt` over `q = 2^252 + 27742317777372353535851937790883648493`. Brand lifetimes on `ResidueCt` keep p-field and q-field residues from cross-contaminating.
- **`sha512_modq_ct`** — branchless Horner-style reduction of a 512-bit hash mod q for the secret nonce derivation.
- **`Signer<[u8; 64]>` for `SigningKey<T>`** — mirrors the existing `Verifier<S>` impl pattern.

## Scope

This PR is intentionally narrow — pure-Ed25519 signing API + `Signer` trait. The following are deliberately deferred to follow-up PRs:

- `bin/sign` and `bin/keygen` updates to use the new API
- Size measurement against the baseline/dummy
- **Ed25519ph (pre-hashed) and Ed25519ctx variants** — these will shape the API once we wire in the broader RustCrypto trait surface; worth a dedicated PR
- Broader RustCrypto trait coverage (`SignerMut`, `KeypairRef`, etc.)

## Test plan

- [x] RFC 8032 §7.1 test vectors 1–3 — byte-exact public keys and signatures
- [x] `signer_matches_rfc8032_test1` — `Signer` trait surface against vector 1
- [x] `signer_verifier_roundtrip` — sign → verify across empty, single-byte, 32-byte, and 129-byte (multi-SHA-512-block) messages
- [ ] Manual: `cargo test --features fixed-bigint,sha512-hmac-sha512` (16/16 lib + integration tests pass)

## Summary by Sourcery

Add constant-time Ed25519 signing support, including a new SigningKey API and Signer trait integration, on top of the existing verify-only crate.

New Features:
- Introduce a generic SigningKey type with seed-based key derivation and cached compressed public key for Ed25519.
- Expose sign and sign_with_fields functions to produce Ed25519 signatures, with an API that amortizes field setup across multiple signatures.
- Implement signature::Signer<[u8; 64]> for SigningKey to integrate with the RustCrypto signature traits.

Enhancements:
- Add constant-time scalar field and point arithmetic primitives, including a Montgomery-ladder based scalar multiplication and point compression for Ed25519.
- Provide a constant-time SHA-512 modulo-q reduction helper and scalar-field factory over the Ed25519 group order to support secure nonce and scalar computations.

Tests:
- Extend tests with RFC 8032 signing vectors and end-to-end signer/verifier roundtrip coverage for multiple message sizes.
- Add internal tests validating constant-time point operations and scalar multiplication correctness against the base point.