### PR TITLE
Bump version 0.2.0 → 0.2.1

### DIFF
--- a/ed25519/Cargo.toml
+++ b/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ed25519_heapless"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2024"
 description = "Ed25519 signature verification and X25519 key exchange, generic over bigint backends"
 license = "GPL-3.0-only"


### PR DESCRIPTION
Bumps the published version line to cover the two PRs landed since the v0.2.0 release on crates.io:

- #25 — panic-site elimination on the upstream-API-stable path
- #26 — Ed25519 sign (`SigningKey`, `sign`, `Signer<[u8; 64]>` trait impl)

Sign is an additive API on top of the existing verify + x25519 surface; no breaking changes to existing callers.