### PR TITLE
Add crates.io and docs.rs badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ### ed25519 heapless fork
 
+[![crate](https://img.shields.io/crates/v/ed25519_heapless.svg)](https://crates.io/crates/ed25519_heapless)
+[![documentation](https://docs.rs/ed25519_heapless/badge.svg)](https://docs.rs/ed25519_heapless/)
 [![Rust](https://github.com/kaidokert/ed25519/actions/workflows/rust.yml/badge.svg)](https://github.com/kaidokert/ed25519/actions/workflows/rust.yml)
 [![AVR](https://github.com/kaidokert/ed25519/actions/workflows/avr.yml/badge.svg)](https://github.com/kaidokert/ed25519/actions/workflows/avr.yml)
 [![Cortex-M](https://github.com/kaidokert/ed25519/actions/workflows/cortex_m.yml/badge.svg)](https://github.com/kaidokert/ed25519/actions/workflows/cortex_m.yml)


### PR DESCRIPTION
Adds version + docs badges at the top of the README, matching the pattern in [`fixed-bigint-rs`](https://github.com/kaidokert/fixed-bigint-rs/blob/main/README.md).

## Summary by Sourcery

Documentation:
- Document crate availability and API docs by adding crates.io and docs.rs badges to the README.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a crates.io version badge to the README.
  * Added a docs.rs badge to the README for easier access to package and API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->